### PR TITLE
feat: Add custom actions for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ GitHub notifications TUI built with Rust and ratatui.
 - Pin important notifications
 - Repository grouping with collapsible headers
 - Notification hooks for custom commands
+- Custom actions with command templates
 - Mark notifications read/unread individually or in bulk
 - Static display mode for scripting and pipelines
 
@@ -93,6 +94,7 @@ gh news --static-display | grep "something" # List notifications without TUI
 - `.` - Toggle read/unread status
 - `!` - Pin/unpin notification (pinned appear at top)
 - `h` - Collapse current repository
+- `x` - Open action menu (run custom commands on notifications)
 
 ### Multi-select
 
@@ -210,6 +212,53 @@ fi
 ```
 
 **Note:** For commands with complex arguments or shell features, use a wrapper script.
+
+### Custom Actions
+
+Define custom actions that can be run on notifications via the action menu (press `x`):
+
+```toml
+[[actions]]
+name = "Copy URL"
+command = "echo {url} | xclip -selection clipboard"
+
+[[actions]]
+name = "Open in editor"
+command = "code --goto {url}"
+
+[[actions]]
+name = "Add to TODO"
+command = "echo '* TODO {title}' >> ~/todo.org"
+
+[[actions]]
+name = "Browse with fzf"
+command = "echo {url} | fzf --preview 'curl -s {}'"
+interactive = true  # Suspend TUI for interactive commands
+```
+
+Actions support placeholder substitution:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{id}` | Notification ID |
+| `{title}` | Notification title |
+| `{url}` | Web URL for the notification |
+| `{repo}` | Repository name (without owner) |
+| `{owner}` | Repository owner |
+| `{full_name}` | Full repository name (owner/repo) |
+| `{type}` | Notification type (Issue, PullRequest, etc.) |
+| `{reason}` | Notification reason (mention, review_requested, etc.) |
+| `{unread}` | Read status (true/false) |
+
+**Action Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `name` | required | Display name in the action menu |
+| `command` | required | Command template with placeholders |
+| `interactive` | `false` | Suspend TUI and run command with full terminal access (for TUI tools like fzf, vim) |
+
+Actions work with multi-select: select multiple notifications with `Space`, then press `x` to run an action on all of them. Interactive actions only run on the first selected notification.
 
 ## Environment Variables
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -154,6 +154,58 @@ auto_mark_read = true
 github_host = "github.com"
 
 # ==============================================================================
+# CUSTOM ACTIONS
+# ==============================================================================
+
+# Define custom actions that can be executed on notifications via the action
+# menu (press 'x'). Actions run shell commands with placeholder substitution.
+#
+# Available placeholders:
+#   - {id}        Notification ID
+#   - {title}     Notification title
+#   - {url}       Web URL for the notification
+#   - {repo}      Repository name (without owner)
+#   - {owner}     Repository owner
+#   - {full_name} Full repository name (owner/repo)
+#   - {type}      Notification type (Issue, PullRequest, etc.)
+#   - {reason}    Notification reason (mention, review_requested, etc.)
+#   - {unread}    Read status (true/false)
+#
+# Options:
+#   - name:        Display name in the action menu (required)
+#   - command:     Command template with placeholders (required)
+#   - interactive: Suspend TUI and run with full terminal access for interactive
+#                  tools like vim, fzf, etc. (default: false)
+#
+# Examples:
+
+# Copy notification URL to clipboard (Linux with xclip)
+# [[actions]]
+# name = "Copy URL"
+# command = "echo {url} | xclip -selection clipboard"
+
+# Copy notification URL to clipboard (macOS)
+# [[actions]]
+# name = "Copy URL"
+# command = "echo {url} | pbcopy"
+
+# Open in VS Code
+# [[actions]]
+# name = "Open in VS Code"
+# command = "code --goto {url}"
+
+# Add to TODO list
+# [[actions]]
+# name = "Add to TODO"
+# command = "echo '* TODO {title}' >> ~/todo.org"
+
+# Open in vim (interactive - suspends TUI)
+# [[actions]]
+# name = "Open in Vim"
+# command = "gh pr view {url} | vim -"
+# interactive = true
+
+# ==============================================================================
 # STATE FILE
 # ==============================================================================
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,427 @@
+use crate::config::Action;
+use crate::models::Notification;
+use std::process::{Command, Stdio};
+
+/// Escape a string for safe use in shell commands.
+/// Uses single-quote wrapping with proper escaping of embedded single quotes.
+fn shell_escape(s: &str) -> String {
+    // Replace single quotes with '\'' (end quote, escaped quote, start quote)
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{}'", escaped)
+}
+
+/// Result of action execution.
+pub enum ActionResult {
+    /// Action spawned in background.
+    Spawned,
+    /// Action failed with error message.
+    Failed(String),
+}
+
+/// Substitute placeholders in a command template with notification data.
+///
+/// Supported placeholders:
+/// - {id} - Notification ID
+/// - {title} - Notification title
+/// - {url} - Web URL for the notification
+/// - {repo} - Repository name (without owner)
+/// - {owner} - Repository owner
+/// - {full_name} - Full repository name (owner/repo)
+/// - {type} - Notification type (Issue, PullRequest, etc.)
+/// - {reason} - Notification reason (mention, review_requested, etc.)
+/// - {unread} - "true" or "false"
+pub fn substitute_placeholders(
+    command: &str,
+    notification: &Notification,
+    github_host: &str,
+) -> String {
+    let repo_full = notification.repo_full_name();
+    let (owner, repo_name) = repo_full.split_once('/').unwrap_or(("", repo_full));
+
+    let url = notification.web_url(github_host).unwrap_or_default();
+
+    // Shell-escape all values to prevent injection attacks
+    command
+        .replace("{id}", &shell_escape(&notification.id))
+        .replace("{title}", &shell_escape(notification.title()))
+        .replace("{url}", &shell_escape(&url))
+        .replace("{repo}", &shell_escape(repo_name))
+        .replace("{owner}", &shell_escape(owner))
+        .replace("{full_name}", &shell_escape(repo_full))
+        .replace(
+            "{type}",
+            &shell_escape(&notification.notification_type().to_string()),
+        )
+        .replace(
+            "{reason}",
+            &shell_escape(&notification.reason_enum().to_string()),
+        )
+        .replace("{unread}", &shell_escape(&notification.unread.to_string()))
+}
+
+/// Execute an action on a notification (spawns in background).
+///
+/// For interactive actions, use `prepare_command` instead and execute with terminal access.
+pub fn execute_action(
+    action: &Action,
+    notification: &Notification,
+    github_host: &str,
+) -> ActionResult {
+    let command = substitute_placeholders(&action.command, notification, github_host);
+
+    if command.trim().is_empty() {
+        return ActionResult::Failed("Empty command".to_string());
+    }
+
+    execute_background(&command)
+}
+
+/// Prepare a command string for execution (with placeholder substitution).
+/// Used for interactive actions where the caller handles execution.
+pub fn prepare_command(action: &Action, notification: &Notification, github_host: &str) -> String {
+    substitute_placeholders(&action.command, notification, github_host)
+}
+
+/// Execute command in background (non-blocking).
+fn execute_background(command: &str) -> ActionResult {
+    // Use shell to handle pipes and complex commands
+    let result = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+
+    match result {
+        Ok(_) => ActionResult::Spawned,
+        Err(e) => ActionResult::Failed(format!("Failed to spawn: {}", e)),
+    }
+}
+
+/// Execute a command interactively with full terminal access.
+/// Returns Ok(exit_success) or Err with error message.
+pub fn execute_interactive(command: &str) -> std::result::Result<bool, String> {
+    let result = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match result {
+        Ok(status) => Ok(status.success()),
+        Err(e) => Err(format!("Failed to execute: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NotificationType, Owner, Repository, Subject};
+
+    fn create_test_notification() -> Notification {
+        Notification {
+            id: "12345".to_string(),
+            unread: true,
+            last_read_at: None,
+            updated_at: None,
+            reason: "mention".to_string(),
+            repository: Repository {
+                id: 1,
+                name: "gh-news".to_string(),
+                full_name: "chmouel/gh-news".to_string(),
+                owner: Owner {
+                    login: "chmouel".to_string(),
+                    id: 1,
+                    owner_type: "User".to_string(),
+                },
+                private: false,
+            },
+            subject: Subject {
+                title: "Test Issue Title".to_string(),
+                subject_type: NotificationType::Issue,
+                url: Some("https://api.github.com/repos/chmouel/gh-news/issues/42".to_string()),
+                latest_comment_url: None,
+            },
+            latest_comment_url: None,
+        }
+    }
+
+    #[test]
+    fn test_shell_escape_basic() {
+        assert_eq!(shell_escape("hello"), "'hello'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_single_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_special_chars() {
+        assert_eq!(shell_escape("$HOME & test | cmd"), "'$HOME & test | cmd'");
+    }
+
+    #[test]
+    fn test_substitute_basic_placeholders() {
+        let notification = create_test_notification();
+        let command = "echo {id} {title}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // Values are shell-escaped with single quotes
+        assert_eq!(result, "echo '12345' 'Test Issue Title'");
+    }
+
+    #[test]
+    fn test_substitute_repo_placeholders() {
+        let notification = create_test_notification();
+        let command = "echo {owner}/{repo} = {full_name}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo 'chmouel'/'gh-news' = 'chmouel/gh-news'");
+    }
+
+    #[test]
+    fn test_substitute_type_and_reason() {
+        let notification = create_test_notification();
+        let command = "echo type={type} reason={reason}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo type='Issue' reason='mention'");
+    }
+
+    #[test]
+    fn test_substitute_unread_status() {
+        let notification = create_test_notification();
+        let command = "echo unread={unread}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo unread='true'");
+    }
+
+    #[test]
+    fn test_substitute_url() {
+        let notification = create_test_notification();
+        let command = "open {url}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert!(result.contains("github.com/chmouel/gh-news/issues/42"));
+    }
+
+    #[test]
+    fn test_execute_background_command() {
+        let action = Action {
+            name: "Test".to_string(),
+            command: "true".to_string(),
+            interactive: false,
+        };
+        let notification = create_test_notification();
+        let result = execute_action(&action, &notification, "github.com");
+        assert!(matches!(result, ActionResult::Spawned));
+    }
+
+    #[test]
+    fn test_prepare_command() {
+        let action = Action {
+            name: "Test".to_string(),
+            command: "echo {id}".to_string(),
+            interactive: true,
+        };
+        let notification = create_test_notification();
+        let result = prepare_command(&action, &notification, "github.com");
+        assert_eq!(result, "echo '12345'");
+    }
+
+    #[test]
+    fn test_empty_command_returns_failed() {
+        let action = Action {
+            name: "Empty".to_string(),
+            command: "".to_string(),
+            interactive: false,
+        };
+        let notification = create_test_notification();
+        let result = execute_action(&action, &notification, "github.com");
+        assert!(matches!(result, ActionResult::Failed(_)));
+    }
+
+    #[test]
+    fn test_whitespace_only_command_returns_failed() {
+        let action = Action {
+            name: "Whitespace".to_string(),
+            command: "   ".to_string(),
+            interactive: false,
+        };
+        let notification = create_test_notification();
+        let result = execute_action(&action, &notification, "github.com");
+        assert!(matches!(result, ActionResult::Failed(_)));
+    }
+
+    #[test]
+    fn test_multiple_placeholders_same_type() {
+        let notification = create_test_notification();
+        let command = "echo {id} and {id} again";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo '12345' and '12345' again");
+    }
+
+    #[test]
+    fn test_all_placeholders_in_one_command() {
+        let notification = create_test_notification();
+        let command = "{id}|{title}|{repo}|{owner}|{full_name}|{type}|{reason}|{unread}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(
+            result,
+            "'12345'|'Test Issue Title'|'gh-news'|'chmouel'|'chmouel/gh-news'|'Issue'|'mention'|'true'"
+        );
+    }
+
+    #[test]
+    fn test_read_notification_unread_false() {
+        let mut notification = create_test_notification();
+        notification.unread = false;
+        let command = "echo {unread}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo 'false'");
+    }
+
+    #[test]
+    fn test_pull_request_type() {
+        let mut notification = create_test_notification();
+        notification.subject.subject_type = NotificationType::PullRequest;
+        notification.subject.url =
+            Some("https://api.github.com/repos/chmouel/gh-news/pulls/99".to_string());
+        let command = "echo {type}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // NotificationType::PullRequest displays as "PR", shell-escaped
+        assert_eq!(result, "echo 'PR'");
+    }
+
+    #[test]
+    fn test_missing_url_falls_back_to_repo_url() {
+        let mut notification = create_test_notification();
+        notification.subject.url = None;
+        let command = "open {url}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // When no subject URL, web_url() falls back to repo URL, shell-escaped
+        assert_eq!(result, "open 'https://github.com/chmouel/gh-news'");
+    }
+
+    #[test]
+    fn test_title_with_special_characters() {
+        let mut notification = create_test_notification();
+        notification.subject.title = "Fix: handle 'quotes' and \"double quotes\"".to_string();
+        let command = "echo {title}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // Single quotes in title are escaped using '\'' pattern
+        assert_eq!(
+            result,
+            "echo 'Fix: handle '\\''quotes'\\'' and \"double quotes\"'"
+        );
+    }
+
+    #[test]
+    fn test_title_with_shell_special_chars() {
+        let mut notification = create_test_notification();
+        notification.subject.title = "Bug: $HOME variable & pipes | test".to_string();
+        let command = "echo {title}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // Shell special chars are safely wrapped in single quotes
+        assert_eq!(result, "echo 'Bug: $HOME variable & pipes | test'");
+    }
+
+    #[test]
+    fn test_pipe_command_placeholder_substitution() {
+        let notification = create_test_notification();
+        let action = Action {
+            name: "PipePlaceholder".to_string(),
+            command: "echo {id} | rev".to_string(),
+            interactive: false,
+        };
+        // Verify placeholder substitution works with pipes
+        let cmd = prepare_command(&action, &notification, "github.com");
+        assert_eq!(cmd, "echo '12345' | rev");
+    }
+
+    #[test]
+    fn test_github_enterprise_url() {
+        let notification = create_test_notification();
+        let command = "open {url}";
+        let result = substitute_placeholders(command, &notification, "github.example.com");
+        assert!(result.contains("github.example.com"));
+    }
+
+    #[test]
+    fn test_different_reasons() {
+        let mut notification = create_test_notification();
+
+        notification.reason = "review_requested".to_string();
+        let result = substitute_placeholders("echo {reason}", &notification, "github.com");
+        assert_eq!(result, "echo 'review_requested'");
+
+        notification.reason = "assign".to_string();
+        let result = substitute_placeholders("echo {reason}", &notification, "github.com");
+        assert_eq!(result, "echo 'assign'");
+
+        notification.reason = "ci_activity".to_string();
+        let result = substitute_placeholders("echo {reason}", &notification, "github.com");
+        assert_eq!(result, "echo 'ci_activity'");
+    }
+
+    #[test]
+    fn test_no_placeholder_command_unchanged() {
+        let notification = create_test_notification();
+        let command = "echo hello world";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert_eq!(result, "echo hello world");
+    }
+
+    #[test]
+    fn test_unknown_placeholder_left_unchanged() {
+        let notification = create_test_notification();
+        let command = "echo {unknown} {id}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // Unknown placeholders are left as-is, known ones are shell-escaped
+        assert_eq!(result, "echo {unknown} '12345'");
+    }
+
+    fn create_pr_notification() -> Notification {
+        Notification {
+            id: "99999".to_string(),
+            unread: false,
+            last_read_at: None,
+            updated_at: None,
+            reason: "review_requested".to_string(),
+            repository: Repository {
+                id: 2,
+                name: "other-repo".to_string(),
+                full_name: "org/other-repo".to_string(),
+                owner: Owner {
+                    login: "org".to_string(),
+                    id: 2,
+                    owner_type: "Organization".to_string(),
+                },
+                private: true,
+            },
+            subject: Subject {
+                title: "Add new feature".to_string(),
+                subject_type: NotificationType::PullRequest,
+                url: Some("https://api.github.com/repos/org/other-repo/pulls/123".to_string()),
+                latest_comment_url: None,
+            },
+            latest_comment_url: None,
+        }
+    }
+
+    #[test]
+    fn test_pr_notification_substitution() {
+        let notification = create_pr_notification();
+        let command = "{owner}/{repo} PR: {title} ({type})";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        // NotificationType::PullRequest displays as "PR", all values shell-escaped
+        assert_eq!(result, "'org'/'other-repo' PR: 'Add new feature' ('PR')");
+    }
+
+    #[test]
+    fn test_pr_notification_url() {
+        let notification = create_pr_notification();
+        let command = "open {url}";
+        let result = substitute_placeholders(command, &notification, "github.com");
+        assert!(result.contains("github.com/org/other-repo/pull/123"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,19 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// A user-defined action that can be executed on notifications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Action {
+    /// Display name shown in the action menu.
+    pub name: String,
+    /// Command template with placeholders like {url}, {title}, {repo}, etc.
+    pub command: String,
+    /// If true, suspend TUI and run command interactively with full terminal access.
+    /// This allows running TUI-based tools like fzf, vim, etc. Default: false.
+    #[serde(default)]
+    pub interactive: bool,
+}
+
 /// Application configuration loaded from config file and environment variables.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -38,6 +51,10 @@ pub struct Config {
 
     // State file path (optional override)
     pub state_file: Option<String>,
+
+    // User-defined actions for notifications
+    #[serde(default)]
+    pub actions: Vec<Action>,
 }
 
 impl Default for Config {
@@ -57,6 +74,7 @@ impl Default for Config {
             on_new_notification_command: None,
             github_host: "github.com".to_string(),
             state_file: None,
+            actions: Vec::new(),
         }
     }
 }
@@ -178,5 +196,70 @@ mod tests {
             config.get_default_preview_mode(),
             PreviewMode::Horizontal
         ));
+    }
+
+    #[test]
+    fn test_default_actions_empty() {
+        let config = Config::default();
+        assert!(config.actions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_actions_from_toml() {
+        let toml_str = r#"
+[[actions]]
+name = "Copy URL"
+command = "echo {url}"
+
+[[actions]]
+name = "Interactive action"
+command = "vim {title}"
+interactive = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.actions.len(), 2);
+
+        assert_eq!(config.actions[0].name, "Copy URL");
+        assert_eq!(config.actions[0].command, "echo {url}");
+        assert!(!config.actions[0].interactive);
+
+        assert_eq!(config.actions[1].name, "Interactive action");
+        assert_eq!(config.actions[1].command, "vim {title}");
+        assert!(config.actions[1].interactive);
+    }
+
+    #[test]
+    fn test_action_interactive_defaults_to_false() {
+        let toml_str = r#"
+[[actions]]
+name = "Test"
+command = "echo test"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(!config.actions[0].interactive);
+    }
+
+    #[test]
+    fn test_parse_single_action() {
+        let toml_str = r#"
+[[actions]]
+name = "Single"
+command = "true"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.actions.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_action_with_placeholders() {
+        let toml_str = r#"
+[[actions]]
+name = "Full"
+command = "{id} {title} {url} {repo} {owner}"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.actions[0].command.contains("{id}"));
+        assert!(config.actions[0].command.contains("{title}"));
+        assert!(config.actions[0].command.contains("{url}"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod actions;
 mod api;
 mod cli;
 mod config;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -48,6 +48,8 @@ pub struct AppState {
     pub selected_notification_ids: HashSet<String>,
     // Progress for batch operations: (current, total)
     pub loading_progress: Option<(usize, usize)>,
+    // Action menu: index of selected action
+    pub action_menu_index: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +60,7 @@ pub enum InputMode {
     HelpSearch,
     Search,
     Confirm,
+    ActionMenu,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,6 +118,7 @@ impl AppState {
             status_message: None,
             selected_notification_ids: HashSet::new(),
             loading_progress: None,
+            action_menu_index: 0,
         }
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,8 +1,12 @@
 use crate::error::Result;
 use crossterm::{
+    cursor::MoveTo,
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
 };
 use ratatui::prelude::*;
 use std::io;
@@ -37,6 +41,39 @@ impl Terminal {
         self.terminal
             .size()
             .map_err(|e| crate::error::Error::Terminal(e.to_string()))
+    }
+
+    /// Suspend the TUI to allow interactive command execution.
+    /// Leaves alternate screen and disables raw mode.
+    pub fn suspend(&mut self) -> Result<()> {
+        disable_raw_mode().map_err(|e| crate::error::Error::Terminal(e.to_string()))?;
+        execute!(
+            self.terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        )
+        .map_err(|e| crate::error::Error::Terminal(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Resume the TUI after interactive command execution.
+    /// Re-enters alternate screen and enables raw mode.
+    pub fn resume(&mut self) -> Result<()> {
+        enable_raw_mode().map_err(|e| crate::error::Error::Terminal(e.to_string()))?;
+        execute!(
+            self.terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            // Clear the actual terminal screen and reset cursor
+            Clear(ClearType::All),
+            MoveTo(0, 0)
+        )
+        .map_err(|e| crate::error::Error::Terminal(e.to_string()))?;
+        // Clear ratatui's internal buffer to force a full redraw
+        self.terminal
+            .clear()
+            .map_err(|e| crate::error::Error::Terminal(e.to_string()))?;
+        Ok(())
     }
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,3 +1,4 @@
+use crate::actions::{self, ActionResult};
 use crate::config::Config;
 use crate::error::Result;
 use crate::filter::Filter;
@@ -8,7 +9,9 @@ use crate::preview::PreviewData;
 use crate::preview_manager::PreviewManager;
 use crate::state::{AppState, ConfirmAction, InputMode, MarkAllOption, PaneFocus, PreviewMode};
 use crate::terminal::Terminal;
-use crate::ui::components::{confirm, filter, help, help_search, list, loading, preview, status};
+use crate::ui::components::{
+    action_menu, confirm, filter, help, help_search, list, loading, preview, status,
+};
 use crossterm::event::{
     self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
     MouseEventKind,
@@ -45,6 +48,14 @@ enum BlockingAction {
     },
 }
 
+/// Pending interactive action to be executed with terminal access.
+struct PendingInteractiveAction {
+    /// The shell command to execute.
+    command: String,
+    /// Action name for status message.
+    action_name: String,
+}
+
 /// Dwell time before auto-marking a notification as read (ms)
 const AUTO_MARK_READ_DWELL_MS: u64 = 400;
 
@@ -60,6 +71,7 @@ pub struct App {
     confirm_widget: confirm::ConfirmWidget,
     loading_widget: loading::LoadingWidget,
     filter_widget: filter::FilterWidget,
+    action_menu_widget: action_menu::ActionMenuWidget,
     api_client: Option<crate::api::GitHubClient>,
     last_refresh: Instant,
     refresh_args: Option<(bool, bool, Option<usize>)>, // (all, participating, max_notifications)
@@ -68,6 +80,7 @@ pub struct App {
     initial_load_rx: Option<Receiver<crate::error::Result<InitialLoadData>>>,
     pending_state_settings: Option<PendingStateSettings>,
     pending_blocking_action: Option<BlockingAction>,
+    pending_interactive_action: Option<PendingInteractiveAction>,
     // Auto-mark-read state
     auto_mark_read_enabled: bool,
     pending_mark_read: Option<(String, Instant)>, // (notification_id, timestamp)
@@ -90,6 +103,7 @@ impl App {
             confirm_widget: confirm::ConfirmWidget::new(),
             loading_widget: loading::LoadingWidget::new(),
             filter_widget: filter::FilterWidget::new(),
+            action_menu_widget: action_menu::ActionMenuWidget::new(),
             api_client: None,
             last_refresh: Instant::now(),
             refresh_args: None,
@@ -98,6 +112,7 @@ impl App {
             initial_load_rx: None,
             pending_state_settings: None,
             pending_blocking_action: None,
+            pending_interactive_action: None,
             auto_mark_read_enabled: auto_mark_read,
             pending_mark_read: None,
             pinned_state_dirty: false,
@@ -607,6 +622,25 @@ impl App {
                 }
             }
 
+            // Handle pending interactive action (requires terminal suspend/resume)
+            if let Some(interactive_action) = self.pending_interactive_action.take() {
+                // Suspend TUI for interactive command
+                terminal.suspend()?;
+
+                // Execute the command with full terminal access
+                let result = actions::execute_interactive(&interactive_action.command);
+
+                // Resume TUI
+                terminal.resume()?;
+
+                // Set status message based on result
+                self.state.status_message = Some(match result {
+                    Ok(true) => format!("{}: done", interactive_action.action_name),
+                    Ok(false) => format!("{}: exited with error", interactive_action.action_name),
+                    Err(e) => format!("{}: {}", interactive_action.action_name, e),
+                });
+            }
+
             // Check for auto-refresh signal (non-blocking)
             if self.config.auto_refresh_interval > 0 && !self.state.loading {
                 let elapsed = self.last_refresh.elapsed();
@@ -846,6 +880,22 @@ impl App {
                     .render(frame, size, action, count, is_filtered);
             }
         }
+
+        // Render action menu as overlay (if active)
+        if self.state.input_mode == InputMode::ActionMenu {
+            let notification_count = if self.state.has_selection() {
+                self.state.selection_count()
+            } else {
+                1
+            };
+            self.action_menu_widget.render(
+                frame,
+                size,
+                &self.config.actions,
+                self.state.action_menu_index,
+                notification_count,
+            );
+        }
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -855,6 +905,7 @@ impl App {
             InputMode::Help => self.handle_help_key(key),
             InputMode::HelpSearch => self.handle_help_search_key(key),
             InputMode::Confirm => self.handle_confirm_key(key),
+            InputMode::ActionMenu => self.handle_action_menu_key(key),
         }
     }
 
@@ -891,6 +942,118 @@ impl App {
             _ => {}
         }
         Ok(())
+    }
+
+    fn handle_action_menu_key(&mut self, key: KeyEvent) -> Result<()> {
+        let action_count = self.config.actions.len();
+        if action_count == 0 {
+            self.state.input_mode = InputMode::Normal;
+            return Ok(());
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.state.input_mode = InputMode::Normal;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.state.action_menu_index > 0 {
+                    self.state.action_menu_index -= 1;
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.state.action_menu_index < action_count - 1 {
+                    self.state.action_menu_index += 1;
+                }
+            }
+            KeyCode::Enter => {
+                self.execute_selected_action();
+                self.state.input_mode = InputMode::Normal;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn execute_selected_action(&mut self) {
+        let action_index = self.state.action_menu_index;
+        let action = match self.config.actions.get(action_index) {
+            Some(a) => a.clone(),
+            None => return,
+        };
+
+        // Collect notifications to run action on
+        let notifications: Vec<Notification> = if self.state.has_selection() {
+            let selected_ids = self.state.get_selected_notification_ids();
+            self.state
+                .notifications
+                .iter()
+                .filter(|n| selected_ids.contains(&n.id))
+                .cloned()
+                .collect()
+        } else if let Some(notif) = self.state.selected_notification() {
+            vec![notif.clone()]
+        } else {
+            return;
+        };
+
+        if notifications.is_empty() {
+            return;
+        }
+
+        let count = notifications.len();
+        let github_host = self.config.github_host.clone();
+        let action_name = action.name.clone();
+
+        // Interactive actions: prepare command and defer execution to main loop
+        // (requires terminal access for suspend/resume)
+        if action.interactive {
+            // For interactive actions, only run on first notification
+            // (interactive commands can't reasonably batch)
+            if let Some(notification) = notifications.first() {
+                let command = actions::prepare_command(&action, notification, &github_host);
+                if !command.trim().is_empty() {
+                    self.pending_interactive_action = Some(PendingInteractiveAction {
+                        command,
+                        action_name,
+                    });
+                }
+            }
+            // Clear selection
+            if self.state.has_selection() {
+                self.state.clear_selection();
+            }
+            return;
+        }
+
+        // Non-interactive actions: spawn in background
+        let mut success_count = 0;
+        let mut last_error = String::new();
+
+        for notification in &notifications {
+            match actions::execute_action(&action, notification, &github_host) {
+                ActionResult::Spawned => {
+                    success_count += 1;
+                }
+                ActionResult::Failed(error) => {
+                    last_error = error;
+                }
+            }
+        }
+
+        // Clear selection after executing action
+        if self.state.has_selection() {
+            self.state.clear_selection();
+        }
+
+        // Build status message
+        let msg = if !last_error.is_empty() {
+            format!("{}: {}", action_name, last_error)
+        } else if count > 1 {
+            format!("{}: ran on {} notifications", action_name, success_count)
+        } else {
+            format!("{}: done", action_name)
+        };
+        self.state.status_message = Some(msg);
     }
 
     fn handle_help_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -1607,6 +1770,19 @@ impl App {
                 self.state.clear_selection();
                 self.state.search_query.clear();
                 self.state.input_mode = InputMode::Search;
+            }
+            KeyCode::Char('x') => {
+                // Open action menu if there are configured actions
+                if !self.config.actions.is_empty() {
+                    // Only open if there's a notification selected or multi-select is active
+                    if self.state.has_selection() || self.state.selected_notification().is_some() {
+                        self.state.action_menu_index = 0;
+                        self.state.input_mode = InputMode::ActionMenu;
+                    }
+                } else {
+                    self.state.status_message =
+                        Some("No actions configured. Add [[actions]] to config.toml".to_string());
+                }
             }
             _ => {}
         }

--- a/src/ui/components/action_menu.rs
+++ b/src/ui/components/action_menu.rs
@@ -1,0 +1,113 @@
+use crate::config::Action;
+use crate::ui::theme::{Theme, TokyoNight};
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+pub struct ActionMenuWidget {
+    theme: Theme,
+}
+
+impl ActionMenuWidget {
+    pub fn new() -> Self {
+        Self {
+            theme: Theme::default(),
+        }
+    }
+
+    pub fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        actions: &[Action],
+        selected_index: usize,
+        notification_count: usize,
+    ) {
+        let colors = TokyoNight::colors();
+
+        // Calculate box dimensions based on content
+        let max_name_len = actions.iter().map(|a| a.name.len()).max().unwrap_or(10);
+        let box_width = (max_name_len + 10).clamp(30, 60) as u16;
+        let box_width = box_width.min(area.width.saturating_sub(4));
+
+        // Height: 2 for borders + 1 for header + actions + 2 for keybindings
+        let content_height = actions.len() as u16 + 4;
+        let box_height = content_height.min(area.height.saturating_sub(4));
+
+        let box_x = (area.width.saturating_sub(box_width)) / 2;
+        let box_y = (area.height.saturating_sub(box_height)) / 2;
+
+        let centered_area = Rect {
+            x: box_x,
+            y: box_y,
+            width: box_width,
+            height: box_height,
+        };
+
+        // Clear the background area
+        frame.render_widget(Clear, centered_area);
+
+        // Build content lines
+        let mut content = Vec::new();
+        content.push(Line::from(""));
+
+        for (i, action) in actions.iter().enumerate() {
+            let is_selected = i == selected_index;
+            let indicator = if is_selected { ">" } else { " " };
+
+            let style = if is_selected {
+                Style::default()
+                    .fg(self.theme.highlight_fg)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                self.theme.title
+            };
+
+            content.push(Line::from(vec![
+                Span::styled(format!(" {} ", indicator), style),
+                Span::styled(&action.name, style),
+            ]));
+        }
+
+        content.push(Line::from(""));
+        content.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("j/k", Style::default().fg(colors.blue)),
+            Span::raw(" select  "),
+            Span::styled("Enter", Style::default().fg(colors.green)),
+            Span::raw(" run  "),
+            Span::styled("Esc", Style::default().fg(colors.red)),
+            Span::raw(" cancel"),
+        ]));
+
+        // Build title
+        let title_text = if notification_count > 1 {
+            format!(" Run on {} Notifications ", notification_count)
+        } else {
+            " Actions ".to_string()
+        };
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(vec![
+                Span::styled(" ", Style::default()),
+                Span::styled(
+                    title_text,
+                    Style::default()
+                        .fg(colors.magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" ", Style::default()),
+            ])
+            .title_alignment(Alignment::Center)
+            .border_style(Style::default().fg(colors.magenta))
+            .border_type(ratatui::widgets::BorderType::Rounded);
+
+        let paragraph = Paragraph::new(content)
+            .block(block)
+            .alignment(Alignment::Left);
+
+        frame.render_widget(paragraph, centered_area);
+    }
+}

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -134,6 +134,10 @@ impl HelpWidget {
                         desc: "Collapse current repository",
                     },
                     HelpLine {
+                        key: "x",
+                        desc: "Run custom action on notification(s)",
+                    },
+                    HelpLine {
                         key: "Ctrl+A",
                         desc: "Archive selected (or mark all read)",
                     },

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod action_menu;
 pub mod confirm;
 pub mod filter;
 pub mod help;


### PR DESCRIPTION
## Summary

- Add user-configurable actions that can be executed on notifications via an action menu
- Press `x` to open the action menu on selected notification(s)
- Actions defined in `config.toml` with command templates and placeholder substitution
- Works with multi-select (Space to select, then `x`)

## Configuration

```toml
[[actions]]
name = "Copy URL"
command = "echo {url} | xclip -selection clipboard"

[[actions]]
name = "Add to TODO"
command = "echo '* TODO {title}' >> ~/todo.org"

[[actions]]
name = "Browse with fzf"
command = "gh pr list --repo {full_name} | fzf"
interactive = true  # Suspend TUI for interactive commands
```

## Placeholders

| Placeholder | Description |
|-------------|-------------|
| `{id}` | Notification ID |
| `{title}` | Notification title |
| `{url}` | Web URL for the notification |
| `{repo}` | Repository name (without owner) |
| `{owner}` | Repository owner |
| `{full_name}` | Full repository name (owner/repo) |
| `{type}` | Notification type (Issue, PR, etc.) |
| `{reason}` | Notification reason (mention, review_requested, etc.) |
| `{unread}` | Read status (true/false) |

## Interactive Mode

When `interactive = true`, the TUI suspends and the command runs with full terminal access. This allows using TUI-based tools like `fzf`, `vim`, or any interactive CLI. After the command exits, the TUI resumes.

## Test plan

- [x] Add sample actions to `~/.config/gh-news/config.toml`
- [x] Run `cargo build && cargo run`
- [x] Navigate to a notification, press `x`
- [x] Verify action menu appears with configured actions
- [x] Select an action with j/k, press Enter
- [x] Verify command executes
- [x] Test interactive action with fzf
- [x] Test with multi-select: Space on several notifications, then `x`
- [x] Run `cargo clippy && cargo fmt && cargo test` (39 tests passing)