### PR TITLE
feat: Add auto-archiving for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ gh-news shows a loading screen while fetching notifications during start-up and 
 - `-r, --mark-read` - Mark all notifications as read (non-interactive)
 - `-s, --static-display` - Print notifications and exit (for scripts)
 - `--no-auto-mark-read` - Disable auto-marking notifications as read when navigating
+- `--no-auto-archive` - Disable auto-archiving notifications when navigating
 - `--state-file <PATH>` - Use a custom state file path (overrides config and default)
 
 ### Examples
@@ -117,7 +118,7 @@ gh news --static-display | grep "something" # List notifications without TUI
 - `Shift+U`/`Shift+D` - Scroll preview (5 lines)
 - `Ctrl+U`/`Ctrl+D` - Scroll preview (page)
 - `1`/`2` - Focus pane 1 (list) / pane 2 (preview)
-- `M` - Toggle auto-mark-read on scroll
+- `M` - Cycle auto-scroll mode (off/read/archive)
 
 ### General
 
@@ -157,6 +158,7 @@ repos_collapsed = false              # start with repos collapsed
 
 # Behaviour
 auto_mark_read = true                # mark notifications read when navigating to them
+auto_archive = false                 # archive notifications when navigating away (implies auto_mark_read)
 
 # External commands
 browser_command = ""         # custom browser, e.g. "firefox" (uses system default if empty)

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,7 @@
 # Some settings are also persisted in state file (~/.cache/gh-news/state.toml)
 # and will override config file values when present:
 #   - auto_mark_read (user's toggle)
+#   - auto_archive (user's toggle)
 #
 # ==============================================================================
 # NETWORK & API SETTINGS
@@ -95,8 +96,16 @@ repos_collapsed = false
 # Automatically mark notifications as read when you navigate away from them.
 # Default: true
 # CLI flag: --no-auto-mark-read
-# Note: Can be toggled at runtime and will be saved to state file.
+# Note: Can be toggled at runtime with M key and saved to state file.
 auto_mark_read = true
+
+# Automatically archive (mark as done) notifications when navigating away.
+# When enabled, auto_mark_read is also forced on.
+# Default: false
+# CLI flag: --no-auto-archive
+# Note: Can be toggled at runtime with M key (cycles off/read/archive)
+#       and saved to state file.
+auto_archive = false
 
 # ==============================================================================
 # EXTERNAL COMMANDS & HOOKS

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,10 @@ pub struct Args {
     #[arg(long)]
     pub no_auto_mark_read: bool,
 
+    /// Disable auto-archiving notifications when navigating
+    #[arg(long)]
+    pub no_auto_archive: bool,
+
     /// Path to state file (overrides config and default)
     #[arg(long)]
     pub state_file: Option<PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
 
     // Behaviour
     pub auto_mark_read: bool,
+    pub auto_archive: bool,
 
     // External commands
     pub browser_command: Option<String>,
@@ -70,6 +71,7 @@ impl Default for Config {
             default_preview_mode: "vertical".to_string(),
             repos_collapsed: false,
             auto_mark_read: true,
+            auto_archive: false,
             browser_command: None,
             on_new_notification_command: None,
             github_host: "github.com".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,14 @@ struct RuntimeOptions {
     max_notifications: Option<usize>,
     filter_pattern: Option<String>,
     auto_mark_read: bool,
+    auto_archive: bool,
 }
 
 impl RuntimeOptions {
     fn from_args_and_config(args: &Args, config: &Config) -> Self {
+        let auto_archive = !args.no_auto_archive && config.auto_archive;
+        // When auto_archive is enabled, auto_mark_read is implicitly forced on
+        let auto_mark_read = auto_archive || (!args.no_auto_mark_read && config.auto_mark_read);
         Self {
             // CLI flags override config (for booleans, CLI true wins)
             show_all: args.all || config.show_read,
@@ -53,8 +57,8 @@ impl RuntimeOptions {
             // CLI takes precedence if provided
             max_notifications: args.max_notifications.or(config.max_notifications),
             filter_pattern: args.filter.clone().or(config.default_filter.clone()),
-            // CLI --no-auto-mark-read overrides config
-            auto_mark_read: !args.no_auto_mark_read && config.auto_mark_read,
+            auto_mark_read,
+            auto_archive,
         }
     }
 }
@@ -139,11 +143,14 @@ fn run() -> Result<()> {
     // Always use config's default preview mode on startup
     let preview_mode = config.get_default_preview_mode();
 
-    // Try to load saved auto_mark_read from state file, fallback to runtime option
-    match state_file::AppStateFile::load_auto_mark_read() {
-        Ok(saved_auto_mark_read) => app.set_auto_mark_read(saved_auto_mark_read),
-        Err(_) => app.set_auto_mark_read(opts.auto_mark_read),
-    }
+    // Load auto-mark-read and auto-archive settings, with persisted state taking precedence.
+    let auto_mark_read =
+        state_file::AppStateFile::load_auto_mark_read().unwrap_or(opts.auto_mark_read);
+    let auto_archive = state_file::AppStateFile::load_auto_archive().unwrap_or(opts.auto_archive);
+
+    // Set initial values. `set_auto_archive` will correctly enforce `auto_mark_read` if needed.
+    app.set_auto_mark_read(auto_mark_read);
+    app.set_auto_archive(auto_archive);
 
     let settings = PendingStateSettings {
         filter,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -374,6 +374,39 @@ impl AppState {
         self.preview_mode != PreviewMode::Off && !self.notifications.is_empty()
     }
 
+    /// Remove a notification from local state entirely (used after archiving).
+    /// Updates filtered_notifications indices to remain consistent.
+    pub fn remove_notification(&mut self, notification_id: &str) {
+        if let Some(pos) = self
+            .notifications
+            .iter()
+            .position(|n| n.id == notification_id)
+        {
+            self.notifications.remove(pos);
+            self.filtered_notifications.retain(|&idx| idx != pos);
+            for idx in &mut self.filtered_notifications {
+                if *idx > pos {
+                    *idx -= 1;
+                }
+            }
+            self.selected_notification_ids.remove(notification_id);
+        }
+    }
+
+    pub fn select_last_notification(&mut self) {
+        for i in (0..self.tree_items.len()).rev() {
+            if matches!(self.tree_items[i], TreeItem::Notification(_)) {
+                self.selected_index = i;
+                return;
+            }
+        }
+        if !self.tree_items.is_empty() {
+            self.selected_index = self.tree_items.len() - 1;
+        } else {
+            self.selected_index = 0;
+        }
+    }
+
     pub fn mark_notification_read(&mut self, notification_id: &str) {
         if let Some(notif) = self
             .notifications

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -52,6 +52,8 @@ pub struct AppStateFile {
     #[serde(default = "default_auto_mark_read")]
     pub auto_mark_read: bool,
     #[serde(default)]
+    pub auto_archive: bool,
+    #[serde(default)]
     pub pinned_notifications: Vec<Notification>,
 }
 
@@ -63,6 +65,7 @@ impl AppStateFile {
     pub fn new(auto_mark_read: bool) -> Self {
         Self {
             auto_mark_read,
+            auto_archive: false,
             pinned_notifications: Vec::new(),
         }
     }
@@ -115,6 +118,17 @@ impl AppStateFile {
     pub fn load_auto_mark_read() -> Result<bool> {
         let state = Self::load_full()?;
         Ok(state.auto_mark_read)
+    }
+
+    pub fn save_auto_archive(auto_archive: bool) -> Result<()> {
+        Self::update_with(default_auto_mark_read(), |state| {
+            state.auto_archive = auto_archive;
+        })
+    }
+
+    pub fn load_auto_archive() -> Result<bool> {
+        let state = Self::load_full()?;
+        Ok(state.auto_archive)
     }
 
     pub fn save_pinned_notifications(pinned: &[Notification]) -> Result<()> {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -83,6 +83,7 @@ pub struct App {
     pending_interactive_action: Option<PendingInteractiveAction>,
     // Auto-mark-read state
     auto_mark_read_enabled: bool,
+    auto_archive_enabled: bool,
     pending_mark_read: Option<(String, Instant)>, // (notification_id, timestamp)
     // Track if pinned notifications need to be saved
     pinned_state_dirty: bool,
@@ -114,6 +115,7 @@ impl App {
             pending_blocking_action: None,
             pending_interactive_action: None,
             auto_mark_read_enabled: auto_mark_read,
+            auto_archive_enabled: false,
             pending_mark_read: None,
             pinned_state_dirty: false,
         }
@@ -121,6 +123,14 @@ impl App {
 
     pub fn set_auto_mark_read(&mut self, enabled: bool) {
         self.auto_mark_read_enabled = enabled;
+    }
+
+    pub fn set_auto_archive(&mut self, enabled: bool) {
+        self.auto_archive_enabled = enabled;
+        // auto_archive implies auto_mark_read
+        if enabled {
+            self.auto_mark_read_enabled = true;
+        }
     }
 
     /// Queue the currently selected notification for auto-mark-read after dwell time
@@ -150,9 +160,18 @@ impl App {
                 // Update local state optimistically
                 self.state.mark_notification_read(notification_id);
 
-                // Call API (non-blocking, log errors)
                 if let Some(ref client) = self.api_client {
-                    if let Err(e) = client.mark_notification_read(notification_id) {
+                    if self.auto_archive_enabled {
+                        if let Err(e) = client.mark_thread_done(notification_id) {
+                            eprintln!("Failed to auto-archive notification: {}", e);
+                        }
+                        // Remove from local state optimistically
+                        self.state.remove_notification(notification_id);
+                        self.state.build_tree();
+                        if self.state.selected_index >= self.state.tree_items.len() {
+                            self.state.select_last_notification();
+                        }
+                    } else if let Err(e) = client.mark_notification_read(notification_id) {
                         eprintln!("Failed to auto-mark notification as read: {}", e);
                     }
                 }
@@ -793,8 +812,14 @@ impl App {
             ])
             .split(size);
 
-        self.status_widget
-            .render(frame, chunks[0], &self.state, &self.config);
+        self.status_widget.render(
+            frame,
+            chunks[0],
+            &self.state,
+            &self.config,
+            self.auto_mark_read_enabled,
+            self.auto_archive_enabled,
+        );
 
         let preview_mode = self.effective_preview_mode();
 
@@ -1683,20 +1708,31 @@ impl App {
                 }
             }
             KeyCode::Char('M') => {
-                // Toggle auto-mark-read on scroll
-                self.auto_mark_read_enabled = !self.auto_mark_read_enabled;
+                // Cycle auto-scroll mode: off -> read -> archive (implies read) -> off
+                if !self.auto_mark_read_enabled && !self.auto_archive_enabled {
+                    // off -> read
+                    self.auto_mark_read_enabled = true;
+                    self.auto_archive_enabled = false;
+                } else if self.auto_mark_read_enabled && !self.auto_archive_enabled {
+                    // read -> archive (implies read)
+                    self.auto_archive_enabled = true;
+                    self.auto_mark_read_enabled = true;
+                } else {
+                    // archive -> off
+                    self.auto_archive_enabled = false;
+                    self.auto_mark_read_enabled = false;
+                }
 
                 // Clear pending mark if disabling
                 if !self.auto_mark_read_enabled {
                     self.pending_mark_read = None;
                 }
 
-                // Save to state file
-                if let Err(e) = crate::state_file::AppStateFile::save_auto_mark_read(
+                let _ = crate::state_file::AppStateFile::save_auto_mark_read(
                     self.auto_mark_read_enabled,
-                ) {
-                    let _ = e;
-                }
+                );
+                let _ =
+                    crate::state_file::AppStateFile::save_auto_archive(self.auto_archive_enabled);
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 // Scroll preview up

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -185,7 +185,7 @@ impl HelpWidget {
                     },
                     HelpLine {
                         key: "M",
-                        desc: "Toggle auto-mark-read on scroll",
+                        desc: "Cycle auto-scroll mode (off/read/archive)",
                     },
                 ],
             },

--- a/src/ui/components/status.rs
+++ b/src/ui/components/status.rs
@@ -17,7 +17,15 @@ impl StatusWidget {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, state: &AppState, config: &Config) {
+    pub fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        state: &AppState,
+        config: &Config,
+        auto_mark_read: bool,
+        auto_archive: bool,
+    ) {
         let colors = crate::ui::theme::TokyoNight::colors();
 
         let interval_text = if config.auto_refresh_interval > 0 {
@@ -93,6 +101,28 @@ impl StatusWidget {
                 Style::default().fg(colors.red).add_modifier(Modifier::BOLD),
             ));
         }
+
+        // Show auto-scroll mode indicator
+        let mode_label = if auto_archive {
+            "M:archive"
+        } else if auto_mark_read {
+            "M:read"
+        } else {
+            "M:off"
+        };
+        status_line.spans.push(Span::raw(" · "));
+        status_line.spans.push(Span::styled(
+            mode_label,
+            if auto_archive {
+                Style::default()
+                    .fg(colors.orange)
+                    .add_modifier(Modifier::BOLD)
+            } else if auto_mark_read {
+                Style::default().fg(colors.green)
+            } else {
+                Style::default().fg(colors.fg_muted)
+            },
+        ));
 
         let paragraph = Paragraph::new(status_line)
             .block(


### PR DESCRIPTION
Introduced an auto-archiving feature that marks notifications as done when navigating away from them. This feature is configurable via the `auto_archive` setting in the configuration file and can be toggled at runtime using the 'M' key, which now cycles through "off", "read", and "archive" modes. When auto-archiving is enabled, auto-marking notifications as read is also implicitly enforced. The state file is updated to persist the auto-archive setting. The help and status UI components were updated to reflect these changes.