### PR TITLE
feat: Add optional org-level grouping to tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ default_filter = ""          # regex filter always applied
 # Display
 default_preview_mode = "vertical"    # "off", "horizontal", or "vertical"
 repos_collapsed = false              # start with repos collapsed
+org_grouping = "auto"               # "off", "auto", or "always"
 
 # Behaviour
 auto_mark_read = true                # mark notifications read when navigating to them

--- a/config.example.toml
+++ b/config.example.toml
@@ -89,6 +89,14 @@ default_preview_mode = "vertical"
 # CLI flag: (not available as flag, set via env or config)
 repos_collapsed = false
 
+# Group notifications by organisation above repository grouping.
+# Options:
+#   - "off":    only group by repository
+#   - "auto":   group by organisation only when an organisation has >1 notifications
+#   - "always": always group by organisation when applicable
+# Default: "auto"
+org_grouping = "auto"
+
 # ==============================================================================
 # BEHAVIOR
 # ==============================================================================

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::state::PreviewMode;
+use crate::state::{OrgGroupingMode, PreviewMode};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -36,6 +36,7 @@ pub struct Config {
     // Display defaults
     pub default_preview_mode: String,
     pub repos_collapsed: bool,
+    pub org_grouping: OrgGroupingMode,
 
     // Behaviour
     pub auto_mark_read: bool,
@@ -70,6 +71,7 @@ impl Default for Config {
             default_filter: None,
             default_preview_mode: "vertical".to_string(),
             repos_collapsed: false,
+            org_grouping: OrgGroupingMode::default(),
             auto_mark_read: true,
             auto_archive: false,
             browser_command: None,
@@ -154,6 +156,7 @@ mod tests {
         assert_eq!(config.pagination_size, 50);
         assert!(!config.show_read);
         assert!(!config.participating_only);
+        assert!(matches!(config.org_grouping, OrgGroupingMode::Auto));
         assert_eq!(config.github_host, "github.com");
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,17 +1,41 @@
 use crate::filter::Filter;
 use crate::models::Notification;
 use crate::preview::PreviewData;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 mod tree;
 
 use tree::TreeBuilder;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OrgGroupingMode {
+    Off,
+    #[default]
+    Auto,
+    Always,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrgHeaderInfo {
+    pub login: String,
+    pub notification_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoHeaderInfo {
+    pub full_name: String,
+    pub display_name: String,
+    pub notification_count: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TreeItem {
-    PinnedHeader,             // Header for pinned notifications section
-    RepositoryHeader(String), // Repository full name
-    Notification(usize),      // Index into notifications
+    PinnedHeader,                     // Header for pinned notifications section
+    OrgHeader(OrgHeaderInfo),         // Organisation header with metadata
+    RepositoryHeader(RepoHeaderInfo), // Repository header with metadata
+    Notification(usize),              // Index into notifications
 }
 
 pub struct AppState {
@@ -19,6 +43,7 @@ pub struct AppState {
     pub filtered_notifications: Vec<usize>, // Indices into notifications
     pub tree_items: Vec<TreeItem>,          // Tree structure for display
     pub expanded_repos: HashMap<String, bool>, // Track which repos are expanded
+    pub org_grouping: OrgGroupingMode,
     pub selected_index: usize,
     pub filter: Option<Filter>,
     pub preview_mode: PreviewMode,
@@ -96,6 +121,7 @@ impl AppState {
             filtered_notifications: Vec::new(),
             tree_items: Vec::new(),
             expanded_repos: HashMap::new(),
+            org_grouping: OrgGroupingMode::default(),
             selected_index: 0,
             filter: None,
             preview_mode: PreviewMode::Vertical, // Preview open by default
@@ -194,6 +220,7 @@ impl AppState {
             &self.filtered_notifications,
             &self.expanded_repos,
             &pinned_ids,
+            self.org_grouping,
         )
         .build();
     }
@@ -230,7 +257,9 @@ impl AppState {
             .get(self.selected_index)
             .and_then(|item| match item {
                 TreeItem::Notification(idx) => self.notifications.get(*idx),
-                TreeItem::RepositoryHeader(_) | TreeItem::PinnedHeader => None,
+                TreeItem::RepositoryHeader(_) | TreeItem::OrgHeader(_) | TreeItem::PinnedHeader => {
+                    None
+                }
             })
     }
 
@@ -238,15 +267,18 @@ impl AppState {
         self.tree_items
             .get(self.selected_index)
             .and_then(|item| match item {
-                TreeItem::RepositoryHeader(repo) => Some(repo.as_str()),
-                TreeItem::Notification(_) | TreeItem::PinnedHeader => None,
+                TreeItem::RepositoryHeader(repo_info) => Some(repo_info.full_name.as_str()),
+                TreeItem::OrgHeader(_) | TreeItem::Notification(_) | TreeItem::PinnedHeader => None,
             })
     }
 
     pub fn parent_repo_for_selected(&self) -> Option<&str> {
-        // If the selected item is a RepositoryHeader, return it directly
-        if let Some(TreeItem::RepositoryHeader(repo)) = self.tree_items.get(self.selected_index) {
-            return Some(repo.as_str());
+        match self.tree_items.get(self.selected_index) {
+            Some(TreeItem::RepositoryHeader(repo_info)) => {
+                return Some(repo_info.full_name.as_str())
+            }
+            Some(TreeItem::OrgHeader(_) | TreeItem::PinnedHeader) => return None,
+            _ => {}
         }
 
         if let Some(TreeItem::Notification(idx)) = self.tree_items.get(self.selected_index) {
@@ -258,8 +290,8 @@ impl AppState {
 
         // Fallback for headers without a direct notification (keeps behaviour for legacy layouts).
         for i in (0..self.selected_index).rev() {
-            if let Some(TreeItem::RepositoryHeader(repo)) = self.tree_items.get(i) {
-                return Some(repo.as_str());
+            if let Some(TreeItem::RepositoryHeader(repo_info)) = self.tree_items.get(i) {
+                return Some(repo_info.full_name.as_str());
             }
         }
 
@@ -315,7 +347,7 @@ impl AppState {
         // If we're on a header, move to the previous visible item.
         if matches!(
             self.tree_items.get(self.selected_index),
-            Some(TreeItem::RepositoryHeader(_) | TreeItem::PinnedHeader)
+            Some(TreeItem::RepositoryHeader(_) | TreeItem::OrgHeader(_) | TreeItem::PinnedHeader)
         ) {
             self.selected_index -= 1;
             return;
@@ -347,7 +379,7 @@ impl AppState {
         // If we're on a header, move to the next visible item.
         if matches!(
             self.tree_items.get(self.selected_index),
-            Some(TreeItem::RepositoryHeader(_) | TreeItem::PinnedHeader)
+            Some(TreeItem::RepositoryHeader(_) | TreeItem::OrgHeader(_) | TreeItem::PinnedHeader)
         ) {
             self.selected_index += 1;
             return;

--- a/src/state/tree.rs
+++ b/src/state/tree.rs
@@ -2,13 +2,14 @@ use crate::models::Notification;
 use chrono::{DateTime, Utc};
 use std::collections::{HashMap, HashSet};
 
-use super::TreeItem;
+use super::{OrgGroupingMode, OrgHeaderInfo, RepoHeaderInfo, TreeItem};
 
 pub struct TreeBuilder<'a> {
     notifications: &'a [Notification],
     filtered_notifications: &'a [usize],
     expanded_repos: &'a HashMap<String, bool>,
     pinned_ids: &'a HashSet<String>,
+    org_grouping: OrgGroupingMode,
 }
 
 impl<'a> TreeBuilder<'a> {
@@ -17,12 +18,14 @@ impl<'a> TreeBuilder<'a> {
         filtered_notifications: &'a [usize],
         expanded_repos: &'a HashMap<String, bool>,
         pinned_ids: &'a HashSet<String>,
+        org_grouping: OrgGroupingMode,
     ) -> Self {
         Self {
             notifications,
             filtered_notifications,
             expanded_repos,
             pinned_ids,
+            org_grouping,
         }
     }
 
@@ -60,32 +63,125 @@ impl<'a> TreeBuilder<'a> {
             }
         }
 
-        let mut repo_groups: HashMap<String, Vec<usize>> = HashMap::new();
-        for idx in regular_indices {
-            if let Some(notif) = self.notifications.get(idx) {
-                let repo_name = notif.repo_full_name().to_string();
-                repo_groups.entry(repo_name).or_default().push(idx);
+        let build_repo_list = |repo_groups: HashMap<String, Vec<usize>>| {
+            let mut repo_list: Vec<(String, Vec<usize>, DateTime<Utc>)> = repo_groups
+                .into_iter()
+                .map(|(repo_name, mut notif_indices)| {
+                    notif_indices.sort_by(|&a, &b| {
+                        let timestamp_a = self
+                            .notifications
+                            .get(a)
+                            .and_then(|n| n.effective_timestamp())
+                            .unwrap_or(DateTime::<Utc>::MIN_UTC);
+                        let timestamp_b = self
+                            .notifications
+                            .get(b)
+                            .and_then(|n| n.effective_timestamp())
+                            .unwrap_or(DateTime::<Utc>::MIN_UTC);
+                        timestamp_b.cmp(&timestamp_a)
+                    });
+
+                    let latest_timestamp = notif_indices
+                        .iter()
+                        .filter_map(|&idx| {
+                            self.notifications
+                                .get(idx)
+                                .and_then(|n| n.effective_timestamp())
+                        })
+                        .max()
+                        .unwrap_or(DateTime::<Utc>::MIN_UTC);
+
+                    (repo_name, notif_indices, latest_timestamp)
+                })
+                .collect();
+
+            repo_list.sort_by(|a, b| b.2.cmp(&a.2));
+            repo_list
+        };
+
+        let append_repos = |tree_items: &mut Vec<TreeItem>,
+                            repo_list: Vec<(String, Vec<usize>, DateTime<Utc>)>,
+                            current_org: Option<&str>| {
+            for (repo_name, notif_indices, _) in repo_list {
+                // Compute display name: strip org prefix if under an org header
+                let display_name = current_org
+                    .and_then(|org| {
+                        repo_name
+                            .split_once('/')
+                            .and_then(|(owner, repo)| (owner == org).then_some(repo))
+                    })
+                    .unwrap_or(&repo_name)
+                    .to_string();
+
+                let notification_count = notif_indices.len();
+
+                tree_items.push(TreeItem::RepositoryHeader(RepoHeaderInfo {
+                    full_name: repo_name.clone(),
+                    display_name,
+                    notification_count,
+                }));
+
+                let is_expanded = *self.expanded_repos.get(&repo_name).unwrap_or(&true);
+                if is_expanded {
+                    for &notif_idx in &notif_indices {
+                        tree_items.push(TreeItem::Notification(notif_idx));
+                    }
+                }
+            }
+        };
+
+        let mut org_counts: HashMap<String, usize> = HashMap::new();
+        for idx in &regular_indices {
+            if let Some(notif) = self.notifications.get(*idx) {
+                if notif.repository.owner.owner_type == "Organization" {
+                    *org_counts
+                        .entry(notif.repository.owner.login.clone())
+                        .or_insert(0) += 1;
+                }
             }
         }
 
-        let mut repo_list: Vec<(String, Vec<usize>, DateTime<Utc>)> = repo_groups
-            .into_iter()
-            .map(|(repo_name, mut notif_indices)| {
-                notif_indices.sort_by(|&a, &b| {
-                    let timestamp_a = self
-                        .notifications
-                        .get(a)
-                        .and_then(|n| n.effective_timestamp())
-                        .unwrap_or(DateTime::<Utc>::MIN_UTC);
-                    let timestamp_b = self
-                        .notifications
-                        .get(b)
-                        .and_then(|n| n.effective_timestamp())
-                        .unwrap_or(DateTime::<Utc>::MIN_UTC);
-                    timestamp_b.cmp(&timestamp_a)
-                });
+        let has_org_notifications = !org_counts.is_empty();
+        let use_org_grouping = has_org_notifications
+            && match self.org_grouping {
+                OrgGroupingMode::Off => false,
+                OrgGroupingMode::Always => true,
+                OrgGroupingMode::Auto => org_counts.values().any(|&c| c > 1),
+            };
 
-                let latest_timestamp = notif_indices
+        if !use_org_grouping {
+            let mut repo_groups: HashMap<String, Vec<usize>> = HashMap::new();
+            for idx in regular_indices {
+                if let Some(notif) = self.notifications.get(idx) {
+                    let repo_name = notif.repo_full_name().to_string();
+                    repo_groups.entry(repo_name).or_default().push(idx);
+                }
+            }
+
+            append_repos(&mut tree_items, build_repo_list(repo_groups), None);
+            return tree_items;
+        }
+
+        let mut org_groups: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut non_org_indices: Vec<usize> = Vec::new();
+
+        for idx in regular_indices {
+            if let Some(notif) = self.notifications.get(idx) {
+                if notif.repository.owner.owner_type == "Organization" {
+                    org_groups
+                        .entry(notif.repository.owner.login.clone())
+                        .or_default()
+                        .push(idx);
+                } else {
+                    non_org_indices.push(idx);
+                }
+            }
+        }
+
+        let mut org_list: Vec<(String, Vec<usize>, DateTime<Utc>)> = org_groups
+            .into_iter()
+            .map(|(org, indices)| {
+                let latest_timestamp = indices
                     .iter()
                     .filter_map(|&idx| {
                         self.notifications
@@ -94,24 +190,139 @@ impl<'a> TreeBuilder<'a> {
                     })
                     .max()
                     .unwrap_or(DateTime::<Utc>::MIN_UTC);
-
-                (repo_name, notif_indices, latest_timestamp)
+                (org, indices, latest_timestamp)
             })
             .collect();
 
-        repo_list.sort_by(|a, b| b.2.cmp(&a.2));
+        org_list.sort_by(|a, b| b.2.cmp(&a.2));
 
-        for (repo_name, notif_indices, _) in repo_list {
-            tree_items.push(TreeItem::RepositoryHeader(repo_name.clone()));
+        for (org, indices, _) in org_list {
+            let notification_count = indices.len();
 
-            let is_expanded = *self.expanded_repos.get(&repo_name).unwrap_or(&true);
-            if is_expanded {
-                for &notif_idx in &notif_indices {
-                    tree_items.push(TreeItem::Notification(notif_idx));
+            tree_items.push(TreeItem::OrgHeader(OrgHeaderInfo {
+                login: org.clone(),
+                notification_count,
+            }));
+
+            let mut repo_groups: HashMap<String, Vec<usize>> = HashMap::new();
+            for idx in indices {
+                if let Some(notif) = self.notifications.get(idx) {
+                    let repo_name = notif.repo_full_name().to_string();
+                    repo_groups.entry(repo_name).or_default().push(idx);
                 }
             }
+
+            append_repos(&mut tree_items, build_repo_list(repo_groups), Some(&org));
+        }
+
+        if !non_org_indices.is_empty() {
+            let mut repo_groups: HashMap<String, Vec<usize>> = HashMap::new();
+            for idx in non_org_indices {
+                if let Some(notif) = self.notifications.get(idx) {
+                    let repo_name = notif.repo_full_name().to_string();
+                    repo_groups.entry(repo_name).or_default().push(idx);
+                }
+            }
+
+            append_repos(&mut tree_items, build_repo_list(repo_groups), None);
         }
 
         tree_items
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NotificationType, Owner, Repository, Subject};
+    use chrono::TimeZone;
+
+    fn notif(id: &str, owner: &str, repo: &str, owner_type: &str, ts: i64) -> Notification {
+        Notification {
+            id: id.to_string(),
+            unread: true,
+            last_read_at: None,
+            updated_at: Some(Utc.timestamp_opt(ts, 0).unwrap()),
+            reason: "subscribed".to_string(),
+            repository: Repository {
+                id: 1,
+                name: repo.to_string(),
+                full_name: format!("{}/{}", owner, repo),
+                owner: Owner {
+                    login: owner.to_string(),
+                    id: 1,
+                    owner_type: owner_type.to_string(),
+                },
+                private: false,
+            },
+            subject: Subject {
+                title: "t".to_string(),
+                subject_type: NotificationType::Issue,
+                url: None,
+                latest_comment_url: None,
+            },
+            latest_comment_url: None,
+        }
+    }
+
+    fn build(notifications: Vec<Notification>, mode: OrgGroupingMode) -> Vec<TreeItem> {
+        let filtered: Vec<usize> = (0..notifications.len()).collect();
+        TreeBuilder::new(
+            &notifications,
+            &filtered,
+            &HashMap::new(),
+            &HashSet::new(),
+            mode,
+        )
+        .build()
+    }
+
+    #[test]
+    fn org_grouping_auto_disabled_when_no_org_has_multiple() {
+        let items = build(
+            vec![
+                notif("1", "org1", "r1", "Organization", 10),
+                notif("2", "org2", "r2", "Organization", 20),
+            ],
+            OrgGroupingMode::Auto,
+        );
+        assert!(!items.iter().any(|i| matches!(i, TreeItem::OrgHeader(_))));
+    }
+
+    #[test]
+    fn org_grouping_auto_enabled_when_org_has_multiple() {
+        let items = build(
+            vec![
+                notif("1", "org1", "r1", "Organization", 10),
+                notif("2", "org1", "r2", "Organization", 20),
+            ],
+            OrgGroupingMode::Auto,
+        );
+        assert!(items
+            .iter()
+            .any(|i| matches!(i, TreeItem::OrgHeader(info) if info.login == "org1")));
+    }
+
+    #[test]
+    fn org_grouping_off_never_emits_org_header() {
+        let items = build(
+            vec![
+                notif("1", "org1", "r1", "Organization", 10),
+                notif("2", "org1", "r2", "Organization", 20),
+            ],
+            OrgGroupingMode::Off,
+        );
+        assert!(!items.iter().any(|i| matches!(i, TreeItem::OrgHeader(_))));
+    }
+
+    #[test]
+    fn org_grouping_always_emits_org_header_when_applicable() {
+        let items = build(
+            vec![notif("1", "org1", "r1", "Organization", 10)],
+            OrgGroupingMode::Always,
+        );
+        assert!(items
+            .iter()
+            .any(|i| matches!(i, TreeItem::OrgHeader(info) if info.login == "org1")));
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -92,8 +92,11 @@ pub struct App {
 impl App {
     pub fn new(config: Config) -> Self {
         let auto_mark_read = config.auto_mark_read;
+        let org_grouping = config.org_grouping;
+        let mut state = AppState::new();
+        state.org_grouping = org_grouping;
         Self {
-            state: AppState::new(),
+            state,
             config,
             should_quit: false,
             list_widget: list::ListWidget::new(),
@@ -210,6 +213,7 @@ impl App {
             });
 
         let mut app_state = AppState::new();
+        app_state.org_grouping = self.config.org_grouping;
         app_state.set_notifications(data.notifications);
         app_state.set_filter(settings.filter);
         app_state.set_filter_pattern(settings.filter_pattern);
@@ -1074,7 +1078,7 @@ impl App {
             let mut success_count = 0;
             let mut last_error = String::new();
 
-            for notification in &notifications {
+            for notification in notifications.iter() {
                 match actions::execute_action(&action, notification, &github_host) {
                     ActionResult::Spawned => {
                         success_count += 1;
@@ -2209,11 +2213,15 @@ impl App {
                                 self.prefetch_next_preview();
                             }
                             self.queue_auto_mark_read();
-                        } else if let Some(crate::state::TreeItem::RepositoryHeader(repo_name)) =
+                        } else if let Some(crate::state::TreeItem::OrgHeader(_)) =
+                            self.state.tree_items.get(clicked_item_idx)
+                        {
+                            // Organisation header - no action
+                        } else if let Some(crate::state::TreeItem::RepositoryHeader(repo_info)) =
                             self.state.tree_items.get(clicked_item_idx)
                         {
                             // Clicked on a repository header - toggle expansion
-                            let repo_name = repo_name.clone();
+                            let repo_name = repo_info.full_name.clone();
                             self.state.toggle_repo_expansion(&repo_name);
 
                             // After toggling, try to select the first notification in this repo

--- a/src/ui/components/list.rs
+++ b/src/ui/components/list.rs
@@ -104,28 +104,47 @@ impl ListWidget {
 
                         ListItem::new(Line::from(line))
                     }
-                    crate::state::TreeItem::RepositoryHeader(repo_name) => {
-                        let is_expanded = app_state
-                            .expanded_repos
-                            .get(repo_name)
-                            .copied()
-                            .unwrap_or(true);
+                    crate::state::TreeItem::OrgHeader(org_info) => {
+                        let colors = TokyoNight::colors();
+                        let mut line = vec![];
 
-                        let notif_count = app_state
-                            .filtered_notifications
-                            .iter()
-                            .filter(|&&idx| {
-                                app_state
-                                    .notifications
-                                    .get(idx)
-                                    .map(|n| {
-                                        n.repo_full_name() == repo_name
-                                            && !app_state.is_pinned(&n.id)
-                                    })
-                                    .unwrap_or(false)
-                            })
-                            .count();
+                        line.push(Span::styled(
+                            "󰊻 ",
+                            if is_selected {
+                                Style::default().fg(self.theme.highlight_fg)
+                            } else {
+                                Style::default().fg(colors.magenta)
+                            },
+                        ));
 
+                        line.push(Span::styled(
+                            format!("{} ", org_info.login),
+                            if is_selected {
+                                Style::default()
+                                    .fg(self.theme.highlight_fg)
+                                    .add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default()
+                                    .fg(colors.magenta)
+                                    .add_modifier(Modifier::BOLD)
+                            },
+                        ));
+
+                        let count_style = if is_selected {
+                            Style::default()
+                                .fg(self.theme.highlight_fg)
+                                .bg(self.theme.highlight_bg)
+                        } else {
+                            Style::default().fg(colors.fg).bg(colors.bg_dark)
+                        };
+                        line.push(Span::styled(
+                            format!(" ({}) ", org_info.notification_count),
+                            count_style.add_modifier(Modifier::BOLD),
+                        ));
+
+                        ListItem::new(Line::from(line))
+                    }
+                    crate::state::TreeItem::RepositoryHeader(repo_info) => {
                         let mut line = vec![];
 
                         let colors = TokyoNight::colors();
@@ -138,7 +157,7 @@ impl ListWidget {
                             },
                         ));
 
-                        let indicator = if is_expanded { " " } else { " " };
+                        let indicator = " ";
                         line.push(Span::styled(
                             indicator,
                             if is_selected {
@@ -149,7 +168,7 @@ impl ListWidget {
                         ));
 
                         line.push(Span::styled(
-                            format!("{} ", repo_name),
+                            format!("{} ", repo_info.display_name),
                             if is_selected {
                                 Style::default()
                                     .fg(self.theme.highlight_fg)
@@ -167,7 +186,7 @@ impl ListWidget {
                             Style::default().fg(colors.fg).bg(colors.bg_dark)
                         };
                         line.push(Span::styled(
-                            format!(" ({}) ", notif_count),
+                            format!(" ({}) ", repo_info.notification_count),
                             count_style.add_modifier(Modifier::BOLD),
                         ));
 


### PR DESCRIPTION
Introduced the ability to group entries at the organization level within the tree view. This feature enhances navigation and organization for users with multiple organizational affiliations by allowing them to collapse or expand entries based on their associated organization. The changes involved modifying configuration parsing, state management for tree rendering, and UI component logic to accommodate this new grouping option.


<img width="1865" height="1242" alt="Screenshot 2026-02-10 at 04 58 36" src="https://github.com/user-attachments/assets/1c5836ed-a717-4b20-900c-0ee7b3568ade" />
