### PR TITLE
feat: add archive shortcut to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ gh news --static-display | grep "something" # List notifications without TUI
 - `Enter` - Open notification in browser and mark as read, or toggle repository collapse on headers
 - `o` - Open notification in browser without marking as read
 - `.` - Toggle read/unread status
+- `d` - Archive (done) notification — removes from inbox
 - `!` - Pin/unpin notification (pinned appear at top)
 - `h` - Collapse current repository
 - `x` - Open action menu (run custom commands on notifications)
@@ -106,6 +107,7 @@ gh news --static-display | grep "something" # List notifications without TUI
 - `Enter` - Open all selected + mark as read
 - `o` - Open all selected without marking as read
 - `.` - Mark all selected as read
+- `d` - Archive all selected
 - `Ctrl+A` - Archive selected (or all if none selected)
 - `Ctrl+Alt+A` - Toggle select all notifications in current repository
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -457,6 +457,17 @@ impl AppState {
         self.selected_notification_ids.iter().cloned().collect()
     }
 
+    pub fn remove_notification(&mut self, notification_id: &str) {
+        self.notifications.retain(|n| n.id != notification_id);
+        self.apply_filter();
+    }
+
+    pub fn remove_notifications(&mut self, notification_ids: &[String]) {
+        let id_set: HashSet<&String> = notification_ids.iter().collect();
+        self.notifications.retain(|n| !id_set.contains(&n.id));
+        self.apply_filter();
+    }
+
     pub fn toggle_select_all_in_repo(&mut self, repo_name: &str) -> usize {
         let mut total_in_repo = 0;
         let mut all_selected = true;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1609,6 +1609,79 @@ impl App {
                     }
                 }
             }
+            KeyCode::Char('d') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                if self.state.has_selection() {
+                    // Archive all selected notifications
+                    let selected_ids = self.state.get_selected_notification_ids();
+                    let count = selected_ids.len();
+
+                    if let Some(ref client) = self.api_client {
+                        for notification_id in &selected_ids {
+                            if let Err(e) = client.mark_thread_done(notification_id) {
+                                eprintln!(
+                                    "Failed to archive notification {}: {}",
+                                    notification_id, e
+                                );
+                            }
+                        }
+                    }
+
+                    let saved_index = self.state.selected_index;
+                    self.state.remove_notifications(&selected_ids);
+                    self.state.clear_selection();
+
+                    // Stay near the same position
+                    if !self.state.tree_items.is_empty() {
+                        self.state.selected_index =
+                            saved_index.min(self.state.tree_items.len() - 1);
+                        if !matches!(
+                            self.state.tree_items.get(self.state.selected_index),
+                            Some(crate::state::TreeItem::Notification(_))
+                        ) {
+                            self.state.select_first_notification();
+                        }
+                    }
+
+                    if self.state.show_preview() {
+                        self.fetch_preview_for_selected_notification();
+                        self.prefetch_next_preview();
+                    }
+
+                    self.state.status_message = Some(format!("Archived {} notifications", count));
+                } else if let Some(notification) = self.state.selected_notification() {
+                    // Archive single notification
+                    let notification_id = notification.id.clone();
+                    let saved_index = self.state.selected_index;
+
+                    if let Some(ref client) = self.api_client {
+                        if let Err(e) = client.mark_thread_done(&notification_id) {
+                            eprintln!("Failed to archive notification: {}", e);
+                        }
+                    }
+
+                    self.state.remove_notification(&notification_id);
+
+                    // Stay at the same position (or clamp to end of list)
+                    if !self.state.tree_items.is_empty() {
+                        self.state.selected_index =
+                            saved_index.min(self.state.tree_items.len() - 1);
+                        // Skip headers — find nearest notification
+                        if !matches!(
+                            self.state.tree_items.get(self.state.selected_index),
+                            Some(crate::state::TreeItem::Notification(_))
+                        ) {
+                            self.state.select_first_notification();
+                        }
+                    }
+
+                    if self.state.show_preview() {
+                        self.fetch_preview_for_selected_notification();
+                        self.prefetch_next_preview();
+                    }
+
+                    self.state.status_message = Some("Archived notification".to_string());
+                }
+            }
             KeyCode::Char('!') => {
                 if self.state.has_selection() {
                     // Toggle pin status of all selected notifications

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -126,6 +126,10 @@ impl HelpWidget {
                         desc: "Toggle read status (or mark selected)",
                     },
                     HelpLine {
+                        key: "d",
+                        desc: "Archive (done) notification(s)",
+                    },
+                    HelpLine {
                         key: "!",
                         desc: "Pin/unpin notification",
                     },


### PR DESCRIPTION
Implemented the 'd' key binding to archive single or selected
notifications. Added backend methods to remove notifications from the
state after successfully marking them as done via the API and updated
the help documentation to reflect the new shortcut.

Fixes #21

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
