### PR TITLE
fix: include version flag in cli metadata

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(name = "gh-news")]
+#[command(name = "gh-news", version)]
 #[command(about = "GitHub notifications TUI built with Rust", long_about = None)]
 pub struct Args {
     /// Show all (read/unread) notifications


### PR DESCRIPTION
Added the version attribute to the clap command configuration to allow the application to report its current version via the --version flag.

Fixes #25