### PR TITLE
feat: Enrich notifications with author status context

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -286,6 +286,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 
@@ -557,6 +558,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -81,6 +81,7 @@ fn event_to_notification(event: &serde_json::Value, event_type: &str) -> Option<
         },
         latest_comment_url: None,
         author: None,
+        context: None,
     })
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -225,6 +225,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -102,6 +102,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -20,6 +20,11 @@ pub struct Notification {
     /// Not part of the GitHub API response — populated via background enrichment.
     #[serde(skip)]
     pub author: Option<String>,
+    /// Contextual state for state_change notifications (e.g. "merged", "closed", "open",
+    /// "closed:completed", "closed:not_planned").
+    /// Not part of the GitHub API response — populated via background enrichment.
+    #[serde(skip)]
+    pub context: Option<String>,
 }
 
 impl Notification {
@@ -107,6 +112,52 @@ impl Notification {
         } else {
             let local_time = Local.from_utc_datetime(&time.naive_utc());
             local_time.format("%d/%b %H:%M").to_string()
+        }
+    }
+
+    /// Return a human-readable description combining reason, type, author, and
+    /// enriched context — much more informative than the raw API reason string.
+    pub fn display_reason(&self) -> String {
+        let reason = self.reason_enum();
+        let ntype = self.notification_type();
+
+        match reason {
+            NotificationReason::StateChange => match self.context.as_deref() {
+                Some("merged") => match &self.author {
+                    Some(a) => format!("merged by @{a}"),
+                    None => "merged".to_string(),
+                },
+                Some("closed:completed") => "closed as completed".to_string(),
+                Some("closed:not_planned") => "closed as not planned".to_string(),
+                Some("closed") => "closed".to_string(),
+                Some("open") => "reopened".to_string(),
+                _ => "state changed".to_string(),
+            },
+            NotificationReason::Comment => match &self.author {
+                Some(a) => format!("@{a} commented"),
+                None => "new comment".to_string(),
+            },
+            NotificationReason::Mention => match &self.author {
+                Some(a) => format!("@{a} mentioned you"),
+                None => "you were mentioned".to_string(),
+            },
+            NotificationReason::ReviewRequested => "review requested".to_string(),
+            NotificationReason::Author => match ntype {
+                NotificationType::PullRequest => "your PR".to_string(),
+                NotificationType::Issue => "your issue".to_string(),
+                _ => "your thread".to_string(),
+            },
+            NotificationReason::Assign => "assigned to you".to_string(),
+            NotificationReason::Subscribed => "new activity".to_string(),
+            NotificationReason::CiActivity => "CI activity".to_string(),
+            NotificationReason::SecurityAlert => "security alert".to_string(),
+            NotificationReason::TeamMention => "team mentioned".to_string(),
+            NotificationReason::ApprovalRequested => "approval requested".to_string(),
+            NotificationReason::Invitation => "invitation".to_string(),
+            NotificationReason::Manual => "subscribed".to_string(),
+            NotificationReason::MemberFeatureRequested => "feature requested".to_string(),
+            NotificationReason::SecurityAdvisoryCredit => "security credit".to_string(),
+            NotificationReason::Unknown => self.reason.clone(),
         }
     }
 
@@ -323,6 +374,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 
@@ -422,5 +474,160 @@ mod tests {
             n.web_url("git.example.com"),
             Some("https://git.example.com/org/proj/discussions/99".to_string())
         );
+    }
+
+    fn make_reason_notification(
+        reason: &str,
+        subject_type: NotificationType,
+        author: Option<&str>,
+        context: Option<&str>,
+    ) -> Notification {
+        let mut n = make_notification_with_type(None, "test", subject_type);
+        n.reason = reason.to_string();
+        n.author = author.map(String::from);
+        n.context = context.map(String::from);
+        n
+    }
+
+    #[test]
+    fn display_reason_state_change_merged_with_author() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::PullRequest,
+            Some("alice"),
+            Some("merged"),
+        );
+        assert_eq!(n.display_reason(), "merged by @alice");
+    }
+
+    #[test]
+    fn display_reason_state_change_merged_no_author() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::PullRequest,
+            None,
+            Some("merged"),
+        );
+        assert_eq!(n.display_reason(), "merged");
+    }
+
+    #[test]
+    fn display_reason_state_change_closed() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::Issue,
+            None,
+            Some("closed"),
+        );
+        assert_eq!(n.display_reason(), "closed");
+    }
+
+    #[test]
+    fn display_reason_state_change_closed_completed() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::Issue,
+            None,
+            Some("closed:completed"),
+        );
+        assert_eq!(n.display_reason(), "closed as completed");
+    }
+
+    #[test]
+    fn display_reason_state_change_closed_not_planned() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::Issue,
+            None,
+            Some("closed:not_planned"),
+        );
+        assert_eq!(n.display_reason(), "closed as not planned");
+    }
+
+    #[test]
+    fn display_reason_state_change_reopened() {
+        let n = make_reason_notification(
+            "state_change",
+            NotificationType::PullRequest,
+            None,
+            Some("open"),
+        );
+        assert_eq!(n.display_reason(), "reopened");
+    }
+
+    #[test]
+    fn display_reason_state_change_no_context() {
+        let n = make_reason_notification("state_change", NotificationType::PullRequest, None, None);
+        assert_eq!(n.display_reason(), "state changed");
+    }
+
+    #[test]
+    fn display_reason_comment_with_author() {
+        let n = make_reason_notification("comment", NotificationType::Issue, Some("bob"), None);
+        assert_eq!(n.display_reason(), "@bob commented");
+    }
+
+    #[test]
+    fn display_reason_comment_no_author() {
+        let n = make_reason_notification("comment", NotificationType::Issue, None, None);
+        assert_eq!(n.display_reason(), "new comment");
+    }
+
+    #[test]
+    fn display_reason_mention_with_author() {
+        let n = make_reason_notification(
+            "mention",
+            NotificationType::PullRequest,
+            Some("carol"),
+            None,
+        );
+        assert_eq!(n.display_reason(), "@carol mentioned you");
+    }
+
+    #[test]
+    fn display_reason_review_requested() {
+        let n = make_reason_notification(
+            "review_requested",
+            NotificationType::PullRequest,
+            None,
+            None,
+        );
+        assert_eq!(n.display_reason(), "review requested");
+    }
+
+    #[test]
+    fn display_reason_author_pr() {
+        let n = make_reason_notification("author", NotificationType::PullRequest, None, None);
+        assert_eq!(n.display_reason(), "your PR");
+    }
+
+    #[test]
+    fn display_reason_author_issue() {
+        let n = make_reason_notification("author", NotificationType::Issue, None, None);
+        assert_eq!(n.display_reason(), "your issue");
+    }
+
+    #[test]
+    fn display_reason_assign() {
+        let n = make_reason_notification("assign", NotificationType::Issue, None, None);
+        assert_eq!(n.display_reason(), "assigned to you");
+    }
+
+    #[test]
+    fn display_reason_subscribed() {
+        let n = make_reason_notification("subscribed", NotificationType::PullRequest, None, None);
+        assert_eq!(n.display_reason(), "new activity");
+    }
+
+    #[test]
+    fn display_reason_ci_activity() {
+        let n = make_reason_notification("ci_activity", NotificationType::CheckSuite, None, None);
+        assert_eq!(n.display_reason(), "CI activity");
+    }
+
+    #[test]
+    fn display_reason_security_alert() {
+        let n = make_reason_notification("security_alert", NotificationType::Unknown, None, None);
+        assert_eq!(n.display_reason(), "security alert");
     }
 }

--- a/src/preview_manager.rs
+++ b/src/preview_manager.rs
@@ -429,6 +429,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/state/tree.rs
+++ b/src/state/tree.rs
@@ -269,6 +269,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -257,6 +257,31 @@ pub fn load_author_cache() -> HashMap<String, String> {
         .unwrap_or_default()
 }
 
+/// Path of the context cache file (sibling of the state file).
+fn get_context_cache_path() -> Result<PathBuf> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or_else(|| Error::Config("Could not determine cache directory".to_string()))?;
+    let dir = cache_dir.join("gh-news");
+    fs::create_dir_all(&dir).map_err(Error::Io)?;
+    Ok(dir.join("contexts.json"))
+}
+
+/// Persist a notification-id → context mapping to disk.
+pub fn save_context_cache(contexts: &HashMap<String, String>) -> Result<()> {
+    let path = get_context_cache_path()?;
+    let json = serde_json::to_string(contexts).map_err(|e| Error::Config(e.to_string()))?;
+    fs::write(&path, json).map_err(Error::Io)
+}
+
+/// Load the previously persisted context cache, returning an empty map on any error.
+pub fn load_context_cache() -> HashMap<String, String> {
+    get_context_cache_path()
+        .ok()
+        .and_then(|p| fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -130,7 +130,14 @@ pub struct App {
     cache_path: Option<PathBuf>,
     cache_options_hash: Option<String>,
     background_refresh_rx: Option<Receiver<crate::error::Result<InitialLoadData>>>,
-    author_enrichment_rx: Option<Receiver<std::collections::HashMap<String, String>>>,
+    author_enrichment_rx: Option<Receiver<EnrichmentResult>>,
+}
+
+/// Results from the background enrichment thread that resolves author logins
+/// and subject state context for notifications.
+struct EnrichmentResult {
+    authors: std::collections::HashMap<String, String>,
+    contexts: std::collections::HashMap<String, String>,
 }
 
 impl App {
@@ -555,37 +562,76 @@ impl App {
         self.last_refresh = Instant::now();
     }
 
-    /// Spawn a background thread that resolves author logins for all notifications
-    /// via their `latest_comment_url`. Results are merged back on the next tick.
+    /// Spawn a background thread that resolves author logins and subject state
+    /// context for notifications. Results are merged back on the next tick.
     fn spawn_author_enrichment(&mut self) {
+        use crate::models::NotificationReason;
+
         self.author_enrichment_rx = None;
 
         let Some(client) = self.api_client.clone() else {
             return;
         };
 
-        // Load the persisted author cache and seed known authors into notifications.
-        let cached = crate::state_file::load_author_cache();
+        // Load persisted caches and seed known values into notifications.
+        let cached_authors = crate::state_file::load_author_cache();
+        let cached_contexts = crate::state_file::load_context_cache();
         for notif in &mut self.state.notifications {
             if notif.author.is_none() {
-                if let Some(author) = cached.get(&notif.id) {
+                if let Some(author) = cached_authors.get(&notif.id) {
                     notif.author = Some(author.clone());
                 }
             }
+            if notif.context.is_none() {
+                if let Some(ctx) = cached_contexts.get(&notif.id) {
+                    notif.context = Some(ctx.clone());
+                }
+            }
         }
-        // Re-apply filter so cached authors take effect immediately.
+        // Re-apply filter so cached values take effect immediately.
         self.reapply_filter_preserving_selection();
 
-        // Collect notifications that still need resolution.
-        let to_fetch: Vec<(String, String)> = self
+        // Each item: (id, comment_url_if_needed, subject_url_if_state_change, is_pr)
+        struct FetchItem {
+            id: String,
+            comment_url: Option<String>,
+            subject_url: Option<String>,
+            is_pr: bool,
+        }
+
+        let to_fetch: Vec<FetchItem> = self
             .state
             .notifications
             .iter()
-            .filter(|n| n.author.is_none())
             .filter_map(|n| {
-                n.latest_comment_url
-                    .as_ref()
-                    .map(|url| (n.id.clone(), url.clone()))
+                let needs_author = n.author.is_none() && n.latest_comment_url.is_some();
+                let needs_context = n.context.is_none()
+                    && n.reason_enum() == NotificationReason::StateChange
+                    && n.subject_url().is_some();
+
+                if !needs_author && !needs_context {
+                    return None;
+                }
+
+                let is_pr = n
+                    .subject_url()
+                    .map(|u| u.contains("/pulls/"))
+                    .unwrap_or(false);
+
+                Some(FetchItem {
+                    id: n.id.clone(),
+                    comment_url: if needs_author {
+                        n.latest_comment_url.clone()
+                    } else {
+                        None
+                    },
+                    subject_url: if needs_context {
+                        n.subject_url().map(String::from)
+                    } else {
+                        None
+                    },
+                    is_pr,
+                })
             })
             .collect();
 
@@ -593,25 +639,93 @@ impl App {
             return;
         }
 
-        let (tx, rx) = mpsc::channel::<std::collections::HashMap<String, String>>();
+        let (tx, rx) = mpsc::channel::<EnrichmentResult>();
 
         std::thread::spawn(move || {
-            let (inner_tx, inner_rx) = mpsc::channel::<(String, String)>();
+            // (id, "author"|"context", value)
+            let (inner_tx, inner_rx) = mpsc::channel::<(String, &'static str, String)>();
 
-            for (id, url) in to_fetch {
+            for item in to_fetch {
                 let client = client.clone();
                 let inner_tx = inner_tx.clone();
                 std::thread::spawn(move || {
-                    if let Ok(Some(author)) = client.get_comment_author(&url) {
-                        let _ = inner_tx.send((id, author));
+                    // Fetch author from latest_comment_url
+                    if let Some(url) = &item.comment_url {
+                        if let Ok(Some(author)) = client.get_comment_author(url) {
+                            let _ = inner_tx.send((item.id.clone(), "author", author));
+                        }
+                    }
+
+                    // Fetch subject state for state_change notifications
+                    if let Some(url) = &item.subject_url {
+                        if let Ok(value) = client.get_json_by_url(url) {
+                            let context = if item.is_pr {
+                                let merged = value
+                                    .get("merged")
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(false);
+                                if merged {
+                                    // Also extract merged_by as author fallback
+                                    if item.comment_url.is_none() {
+                                        if let Some(login) = value
+                                            .get("merged_by")
+                                            .and_then(|u| u.get("login"))
+                                            .and_then(|l| l.as_str())
+                                        {
+                                            let _ = inner_tx.send((
+                                                item.id.clone(),
+                                                "author",
+                                                login.to_string(),
+                                            ));
+                                        }
+                                    }
+                                    "merged".to_string()
+                                } else {
+                                    value
+                                        .get("state")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("open")
+                                        .to_lowercase()
+                                }
+                            } else {
+                                let state = value
+                                    .get("state")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("open")
+                                    .to_lowercase();
+                                if state == "closed" {
+                                    if let Some(reason) =
+                                        value.get("state_reason").and_then(|v| v.as_str())
+                                    {
+                                        format!("closed:{reason}")
+                                    } else {
+                                        state
+                                    }
+                                } else {
+                                    state
+                                }
+                            };
+                            let _ = inner_tx.send((item.id.clone(), "context", context));
+                        }
                     }
                 });
             }
-            // Drop the sender so inner_rx drains completely.
             drop(inner_tx);
 
-            let results: std::collections::HashMap<String, String> = inner_rx.into_iter().collect();
-            let _ = tx.send(results);
+            let mut authors = std::collections::HashMap::new();
+            let mut contexts = std::collections::HashMap::new();
+            for (id, kind, value) in inner_rx {
+                match kind {
+                    "author" => {
+                        authors.insert(id, value);
+                    }
+                    "context" => {
+                        contexts.insert(id, value);
+                    }
+                    _ => {}
+                }
+            }
+            let _ = tx.send(EnrichmentResult { authors, contexts });
         });
 
         self.author_enrichment_rx = Some(rx);
@@ -1143,18 +1257,21 @@ impl App {
                 }
             }
 
-            // Poll author enrichment results
+            // Poll enrichment results (authors + contexts)
             if let Some(ref rx) = self.author_enrichment_rx {
                 match rx.try_recv() {
-                    Ok(authors) => {
+                    Ok(result) => {
                         self.author_enrichment_rx = None;
                         for notif in &mut self.state.notifications {
-                            if let Some(author) = authors.get(&notif.id) {
+                            if let Some(author) = result.authors.get(&notif.id) {
                                 notif.author = Some(author.clone());
+                            }
+                            if let Some(ctx) = result.contexts.get(&notif.id) {
+                                notif.context = Some(ctx.clone());
                             }
                         }
                         self.reapply_filter_preserving_selection();
-                        // Persist resolved authors for future sessions.
+                        // Persist resolved authors and contexts for future sessions.
                         let all_authors: std::collections::HashMap<String, String> = self
                             .state
                             .notifications
@@ -1162,6 +1279,13 @@ impl App {
                             .filter_map(|n| n.author.as_ref().map(|a| (n.id.clone(), a.clone())))
                             .collect();
                         let _ = crate::state_file::save_author_cache(&all_authors);
+                        let all_contexts: std::collections::HashMap<String, String> = self
+                            .state
+                            .notifications
+                            .iter()
+                            .filter_map(|n| n.context.as_ref().map(|c| (n.id.clone(), c.clone())))
+                            .collect();
+                        let _ = crate::state_file::save_context_cache(&all_contexts);
                     }
                     Err(TryRecvError::Disconnected) => {
                         self.author_enrichment_rx = None;
@@ -3441,6 +3565,7 @@ mod tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 
@@ -3475,6 +3600,7 @@ mod tests {
             },
             latest_comment_url: latest_comment_url.map(str::to_string),
             author: None,
+            context: None,
         }
     }
 
@@ -3772,6 +3898,7 @@ mod action_tests {
             },
             latest_comment_url: None,
             author: None,
+            context: None,
         }
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -612,10 +612,7 @@ impl App {
                     return None;
                 }
 
-                let is_pr = n
-                    .subject_url()
-                    .map(|u| u.contains("/pulls/"))
-                    .unwrap_or(false);
+                let is_pr = n.notification_type() == NotificationType::PullRequest;
 
                 Some(FetchItem {
                     id: n.id.clone(),

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -605,9 +605,8 @@ impl App {
             .iter()
             .filter_map(|n| {
                 let needs_author = n.author.is_none() && n.latest_comment_url.is_some();
-                let needs_context = n.context.is_none()
-                    && n.reason_enum() == NotificationReason::StateChange
-                    && n.subject_url().is_some();
+                let needs_context =
+                    n.reason_enum() == NotificationReason::StateChange && n.subject_url().is_some();
 
                 if !needs_author && !needs_context {
                     return None;
@@ -3781,6 +3780,20 @@ mod tests {
     }
 
     #[test]
+    fn state_change_enrichment_runs_with_cached_context() {
+        let mut app = App::new(Config::default());
+        app.set_api_client(GitHubClient::new_test());
+
+        let mut notification = notification_with("1", "State changed", "state_change", None);
+        notification.context = Some("closed".to_string());
+        notification.subject.url = Some("http://127.0.0.1:9/repos/owner/repo/issues/1".to_string());
+
+        app.merge_refreshed_notifications(vec![notification]);
+
+        assert!(app.author_enrichment_rx.is_some());
+    }
+
+    #[test]
     fn mark_all_confirm_message_mentions_filtered_notifications() {
         let mut app = App::new(Config::default());
         app.base_filter = Some(Filter::from_pattern(Some("Alpha")).unwrap());
@@ -3806,9 +3819,10 @@ mod tests {
 
     #[test]
     fn open_selection_prints_pluralised_status_for_print_method() {
-        let mut config = Config::default();
-        config.open_method = OpenMethod::Print;
-        let mut app = App::new(config);
+        let mut app = App::new(Config {
+            open_method: OpenMethod::Print,
+            ..Config::default()
+        });
         app.state.set_notifications(vec![
             test_notification("1", true),
             test_notification("2", true),
@@ -3828,10 +3842,11 @@ mod tests {
 
     #[test]
     fn enter_selection_pluralises_without_auto_mark_on_open() {
-        let mut config = Config::default();
-        config.open_method = OpenMethod::Print;
-        config.auto_mark_on_open = false;
-        let mut app = App::new(config);
+        let mut app = App::new(Config {
+            open_method: OpenMethod::Print,
+            auto_mark_on_open: false,
+            ..Config::default()
+        });
         app.state
             .set_notifications(vec![test_notification("1", true)]);
         app.state.toggle_selection("1".to_string());

--- a/src/ui/components/list.rs
+++ b/src/ui/components/list.rs
@@ -296,7 +296,7 @@ impl ListWidget {
                                     let inner_width = area.width.saturating_sub(4) as usize;
                                     let left_width = 2 + 2 + time.chars().count() + 1 + 2;
 
-                                    let reason_str = format!("{reason}");
+                                    let reason_str = notif.display_reason();
                                     let right_text = match notif.subject_number() {
                                         Some(ref n) => format!("#{n} {reason_str}"),
                                         None => reason_str,
@@ -341,12 +341,13 @@ impl ListWidget {
                                         dot_span,
                                         Span::styled(notif.title().to_string(), title_style),
                                     ]);
+                                    let display_reason = notif.display_reason();
                                     let sub_text = match notif.subject_number() {
                                         Some(ref n) => format!(
-                                            "  ↳ #{n} • {time} • {notification_type} • {reason}"
+                                            "  ↳ #{n} • {time} • {notification_type} • {display_reason}"
                                         ),
                                         None => {
-                                            format!("  ↳ {time} • {notification_type} • {reason}")
+                                            format!("  ↳ {time} • {notification_type} • {display_reason}")
                                         }
                                     };
                                     let line2 = Line::from(Span::styled(

--- a/src/workflow_runs.rs
+++ b/src/workflow_runs.rs
@@ -116,5 +116,6 @@ fn run_to_notification(
         },
         latest_comment_url: None,
         author: None,
+        context: None,
     })
 }


### PR DESCRIPTION
Added a context field to notifications to track specific states like
merged pull requests or completed issues. Extended background
enrichment to fetch these details alongside author information.
Implemented a formatting method to show descriptive status labels in
the UI instead of raw API reason codes. Added a persistent cache to
store this metadata across restarts.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
