### PR TITLE
Implement loading issue/PR comments for current notification on user keypress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -132,15 +132,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -193,9 +193,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -343,7 +343,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "mio 1.2.0",
+ "mio 1.2.1",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -658,9 +658,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -943,9 +943,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1633,9 +1633,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1655,7 +1655,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.2.0",
+ "mio 1.2.1",
  "signal-hook",
 ]
 
@@ -1699,9 +1699,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1930,7 +1930,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.2.1",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -2071,9 +2071,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2193,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2216,18 +2216,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2694,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2717,18 +2717,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -288,6 +288,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 
@@ -561,6 +564,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -1,7 +1,7 @@
 use crate::api::get_github_token;
 use crate::config::Config;
 use crate::error::{ApiError, Error, Result};
-use crate::models::Notification;
+use crate::models::{IssueComment, Notification, PullRequestComment};
 use reqwest::blocking::{Client, RequestBuilder, Response};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, ETAG, IF_NONE_MATCH, USER_AGENT};
 use reqwest::Method;
@@ -273,6 +273,151 @@ impl GitHubClient {
             .and_then(|u| u.get("login"))
             .and_then(|l| l.as_str())
             .map(|s| s.to_string()))
+    }
+
+    /// Fetch both issue comments and review comments for a pull request.
+    pub fn get_pull_request_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: &str,
+        per_page: usize,
+    ) -> Result<Vec<PullRequestComment>> {
+        let page_size = per_page.clamp(1, MAX_PER_PAGE);
+        let issue_comments_url = format!(
+            "{}/repos/{}/{}/issues/{}/comments?per_page={}",
+            self.api_base, owner, repo, number, page_size
+        );
+        let review_comments_url = format!(
+            "{}/repos/{}/{}/pulls/{}/comments?per_page={}",
+            self.api_base, owner, repo, number, page_size
+        );
+
+        let issue_comments_value: Value = self.get_json(&issue_comments_url)?;
+        let review_comments_value: Value = self.get_json(&review_comments_url)?;
+
+        let mut comments = Self::parse_pull_request_comments(&issue_comments_value, false);
+        comments.extend(Self::parse_pull_request_comments(
+            &review_comments_value,
+            true,
+        ));
+        comments.sort_by_key(|left| left.created_at);
+        Ok(comments)
+    }
+
+    /// Fetch issue comments for an issue thread.
+    pub fn get_issue_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: &str,
+        per_page: usize,
+    ) -> Result<Vec<IssueComment>> {
+        let page_size = per_page.clamp(1, MAX_PER_PAGE);
+        let issue_comments_url = format!(
+            "{}/repos/{}/{}/issues/{}/comments?per_page={}",
+            self.api_base, owner, repo, number, page_size
+        );
+
+        let issue_comments_value: Value = self.get_json(&issue_comments_url)?;
+        let mut comments = Self::parse_issue_comments(&issue_comments_value);
+        comments.sort_by_key(|left| left.created_at);
+        Ok(comments)
+    }
+
+    fn parse_pull_request_comments(value: &Value, is_review: bool) -> Vec<PullRequestComment> {
+        value
+            .as_array()
+            .map(|comments| {
+                comments
+                    .iter()
+                    .filter_map(|comment| {
+                        let body = comment
+                            .get("body")
+                            .and_then(|v| v.as_str())
+                            .map(str::trim)
+                            .unwrap_or("");
+                        if body.is_empty() {
+                            return None;
+                        }
+
+                        let author = comment
+                            .get("user")
+                            .and_then(|u| u.get("login"))
+                            .and_then(|l| l.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+
+                        let created_at = comment
+                            .get("created_at")
+                            .and_then(|v| v.as_str())
+                            .and_then(|v| chrono::DateTime::parse_from_rfc3339(v).ok())
+                            .map(|v| v.with_timezone(&chrono::Utc));
+
+                        let url = comment
+                            .get("html_url")
+                            .or_else(|| comment.get("url"))
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+
+                        Some(PullRequestComment {
+                            author,
+                            body: body.to_string(),
+                            created_at,
+                            url,
+                            is_review,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn parse_issue_comments(value: &Value) -> Vec<IssueComment> {
+        value
+            .as_array()
+            .map(|comments| {
+                comments
+                    .iter()
+                    .filter_map(|comment| {
+                        let body = comment
+                            .get("body")
+                            .and_then(|v| v.as_str())
+                            .map(str::trim)
+                            .unwrap_or("");
+                        if body.is_empty() {
+                            return None;
+                        }
+
+                        let author = comment
+                            .get("user")
+                            .and_then(|u| u.get("login"))
+                            .and_then(|l| l.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+
+                        let created_at = comment
+                            .get("created_at")
+                            .and_then(|v| v.as_str())
+                            .and_then(|v| chrono::DateTime::parse_from_rfc3339(v).ok())
+                            .map(|v| v.with_timezone(&chrono::Utc));
+
+                        let url = comment
+                            .get("html_url")
+                            .or_else(|| comment.get("url"))
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+
+                        Some(IssueComment {
+                            author,
+                            body: body.to_string(),
+                            created_at,
+                            url,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub fn mark_all_read(&self, last_read_at: Option<&str>) -> Result<()> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -98,6 +98,9 @@ pub(crate) fn event_to_notification(
         author: Some(actor.to_string()),
         context: Some(event_type.to_string()),
         event_body,
+        pr_comments: Vec::new(),
+        issue_comments: Vec::new(),
+        comments_requested: false,
     })
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -231,6 +231,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -104,6 +104,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -4,6 +4,23 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequestComment {
+    pub author: String,
+    pub body: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub url: Option<String>,
+    pub is_review: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueComment {
+    pub author: String,
+    pub body: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Notification {
     pub id: String,
     pub unread: bool,
@@ -30,6 +47,18 @@ pub struct Notification {
     /// Not part of the GitHub API response — populated when converting events to notifications.
     #[serde(skip)]
     pub event_body: Option<String>,
+    /// Pull request comments (issue comments and review comments) for PR subjects.
+    /// Not part of the GitHub notifications API response — populated via follow-up API calls.
+    #[serde(skip, default)]
+    pub pr_comments: Vec<PullRequestComment>,
+    /// Issue comments for issue subjects.
+    /// Not part of the GitHub notifications API response — populated via follow-up API calls.
+    #[serde(skip, default)]
+    pub issue_comments: Vec<IssueComment>,
+    /// Whether detailed comments should be fetched for previews.
+    /// Set interactively by the user to avoid eager API calls.
+    #[serde(skip, default)]
+    pub comments_requested: bool,
 }
 
 impl Notification {
@@ -420,6 +449,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,6 +1,6 @@
 use crate::api::GitHubClient;
 use crate::error::Result;
-use crate::models::{Notification, NotificationType};
+use crate::models::{IssueComment, Notification, NotificationType, PullRequestComment};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -21,6 +21,8 @@ pub enum PreviewData {
         additions: u64,
         deletions: u64,
         changed_files: u64,
+        #[serde(default)]
+        pr_comments: Vec<PullRequestComment>,
     },
     Issue {
         number: String,
@@ -31,6 +33,8 @@ pub enum PreviewData {
         comments: u64,
         body: String,
         labels: Vec<String>,
+        #[serde(default)]
+        issue_comments: Vec<IssueComment>,
     },
     Commit {
         sha: String,
@@ -523,13 +527,25 @@ impl PreviewFetcher {
                 // Extract number from subject URL
                 let number =
                     Self::extract_number_from_url(notification.subject_url(), notification_type)?;
-                Self::fetch_issue_preview(client, repo_full_name, number)?
+                Self::fetch_issue_preview(
+                    client,
+                    repo_full_name,
+                    number,
+                    &notification.issue_comments,
+                    notification.comments_requested,
+                )?
             }
             NotificationType::PullRequest => {
                 // Extract number from subject URL
                 let number =
                     Self::extract_number_from_url(notification.subject_url(), notification_type)?;
-                Self::fetch_pr_preview(client, repo_full_name, number)?
+                Self::fetch_pr_preview(
+                    client,
+                    repo_full_name,
+                    number,
+                    &notification.pr_comments,
+                    notification.comments_requested,
+                )?
             }
             NotificationType::Commit => {
                 // Extract SHA from subject URL
@@ -650,6 +666,8 @@ impl PreviewFetcher {
         client: &GitHubClient,
         repo: &str,
         number: String,
+        preloaded_comments: &[IssueComment],
+        comments_requested: bool,
     ) -> Result<PreviewData> {
         let (owner, repo_name) = repo
             .split_once('/')
@@ -702,6 +720,16 @@ impl PreviewFetcher {
             .and_then(|v| v.as_str())
             .unwrap_or("No description")
             .to_string();
+        let issue_comments = if !comments_requested {
+            Vec::new()
+        } else if preloaded_comments.is_empty() {
+            client
+                .get_issue_comments(owner, repo_name, &number, 30)
+                .unwrap_or_default()
+        } else {
+            preloaded_comments.to_vec()
+        };
+        let body = Self::format_issue_body_with_comments(&body, &issue_comments);
         let state = issue
             .get("state")
             .and_then(|v| v.as_str())
@@ -734,10 +762,36 @@ impl PreviewFetcher {
             comments,
             body,
             labels,
+            issue_comments,
         })
     }
 
-    fn fetch_pr_preview(client: &GitHubClient, repo: &str, number: String) -> Result<PreviewData> {
+    fn format_issue_body_with_comments(body: &str, comments: &[IssueComment]) -> String {
+        if comments.is_empty() {
+            return body.to_string();
+        }
+
+        let mut sections = vec![body.to_string(), "## Comments".to_string()];
+
+        for comment in comments {
+            let when = comment
+                .created_at
+                .map(|ts| ts.format("%Y-%m-%d %H:%M UTC").to_string())
+                .unwrap_or_else(|| "unknown time".to_string());
+            sections.push(format!("### @{} ({when})", comment.author));
+            sections.push(comment.body.clone());
+        }
+
+        sections.join("\n\n")
+    }
+
+    fn fetch_pr_preview(
+        client: &GitHubClient,
+        repo: &str,
+        number: String,
+        preloaded_comments: &[PullRequestComment],
+        comments_requested: bool,
+    ) -> Result<PreviewData> {
         let (owner, repo_name) = repo
             .split_once('/')
             .ok_or_else(|| crate::error::Error::Config("Invalid repo format".to_string()))?;
@@ -802,6 +856,16 @@ impl PreviewFetcher {
             .and_then(|v| v.as_str())
             .unwrap_or("No description")
             .to_string();
+        let pr_comments = if !comments_requested {
+            Vec::new()
+        } else if preloaded_comments.is_empty() {
+            client
+                .get_pull_request_comments(owner, repo_name, &number, 30)
+                .unwrap_or_default()
+        } else {
+            preloaded_comments.to_vec()
+        };
+        let body = Self::format_pull_request_body_with_comments(&body, &pr_comments);
         let merged = pr.get("merged").and_then(|v| v.as_bool()).unwrap_or(false);
         let state = if merged {
             "merged".to_string()
@@ -864,7 +928,35 @@ impl PreviewFetcher {
             additions,
             deletions,
             changed_files,
+            pr_comments,
         })
+    }
+
+    fn format_pull_request_body_with_comments(
+        body: &str,
+        comments: &[PullRequestComment],
+    ) -> String {
+        if comments.is_empty() {
+            return body.to_string();
+        }
+
+        let mut sections = vec![body.to_string(), "## Comments".to_string()];
+
+        for comment in comments {
+            let kind = if comment.is_review {
+                "review comment"
+            } else {
+                "comment"
+            };
+            let when = comment
+                .created_at
+                .map(|ts| ts.format("%Y-%m-%d %H:%M UTC").to_string())
+                .unwrap_or_else(|| "unknown time".to_string());
+            sections.push(format!("### @{} ({kind}, {when})", comment.author));
+            sections.push(comment.body.clone());
+        }
+
+        sections.join("\n\n")
     }
 
     fn fetch_commit_preview(client: &GitHubClient, repo: &str, sha: &str) -> Result<PreviewData> {
@@ -1523,6 +1615,7 @@ mod tests {
             additions: 0,
             deletions: 0,
             changed_files: 0,
+            pr_comments: Vec::new(),
         };
         let closed_draft = PreviewData::PullRequest {
             number: "2".to_string(),
@@ -1539,6 +1632,7 @@ mod tests {
             additions: 0,
             deletions: 0,
             changed_files: 0,
+            pr_comments: Vec::new(),
         };
         let merged_draft = PreviewData::PullRequest {
             number: "3".to_string(),
@@ -1555,6 +1649,7 @@ mod tests {
             additions: 0,
             deletions: 0,
             changed_files: 0,
+            pr_comments: Vec::new(),
         };
 
         let open_header = PreviewView::from(&open_draft).header[0].text();
@@ -1564,5 +1659,28 @@ mod tests {
         assert!(open_header.ends_with("[draft]"));
         assert!(closed_header.ends_with("[closed]"));
         assert!(merged_header.ends_with("[merged]"));
+    }
+
+    #[test]
+    fn format_issue_body_with_comments_appends_comment_section() {
+        let comments = vec![IssueComment {
+            author: "octocat".to_string(),
+            body: "LGTM!".to_string(),
+            created_at: None,
+            url: Some("https://github.com/owner/repo/issues/1#issuecomment-1".to_string()),
+        }];
+
+        let body = PreviewFetcher::format_issue_body_with_comments("Issue body", &comments);
+
+        assert!(body.contains("Issue body"));
+        assert!(body.contains("## Comments"));
+        assert!(body.contains("@octocat"));
+        assert!(body.contains("LGTM!"));
+    }
+
+    #[test]
+    fn format_issue_body_with_comments_keeps_body_when_no_comments() {
+        let body = PreviewFetcher::format_issue_body_with_comments("Issue body", &[]);
+        assert_eq!(body, "Issue body");
     }
 }

--- a/src/preview_manager.rs
+++ b/src/preview_manager.rs
@@ -505,6 +505,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/state/tree.rs
+++ b/src/state/tree.rs
@@ -272,6 +272,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1332,6 +1332,47 @@ impl App {
         }
     }
 
+    fn request_comments_for_selected_notification(&mut self) {
+        let Some(notification_id) = self.state.selected_notification().map(|n| n.id.clone()) else {
+            self.state.status_message = Some("No notification selected".to_string());
+            return;
+        };
+
+        let Some(notification) = self
+            .state
+            .notifications
+            .iter_mut()
+            .find(|n| n.id == notification_id)
+        else {
+            return;
+        };
+
+        if !matches!(
+            notification.notification_type(),
+            NotificationType::Issue | NotificationType::PullRequest
+        ) {
+            self.state.status_message =
+                Some("Comments are only supported for issues and pull requests".to_string());
+            return;
+        }
+
+        notification.comments_requested = true;
+        notification.issue_comments.clear();
+        notification.pr_comments.clear();
+        let notification = notification.clone();
+
+        if let Some(preview_manager) = self.preview_manager.as_ref() {
+            preview_manager.request_revalidation(&notification, PRIORITY_HIGH);
+        }
+
+        self.state.preview_content = Some(PreviewData::Generic {
+            title: "Loading comments...".to_string(),
+            body: "⏳ Fetching comments...\n\nThis may take a moment.".to_string(),
+        });
+        self.state.preview_scroll = 0;
+        self.state.status_message = Some("Loading comments for selected thread...".to_string());
+    }
+
     pub fn fetch_preview_for_selected(&mut self) {
         self.auto_fetch_preview_for_selected();
     }
@@ -2632,6 +2673,9 @@ impl App {
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.should_quit = true;
             }
+            KeyCode::Char('c') => {
+                self.request_comments_for_selected_notification();
+            }
             KeyCode::Char('?') => {
                 self.open_help();
             }
@@ -3847,6 +3891,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 
@@ -3883,6 +3930,9 @@ mod tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 
@@ -4281,6 +4331,39 @@ mod tests {
             Some("Printed 1 notification")
         );
     }
+
+    #[test]
+    fn key_c_requests_comments_for_selected_issue() {
+        let mut app = App::new(Config::default());
+        app.state
+            .set_notifications(vec![test_notification("issue-1", true)]);
+
+        app.handle_normal_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(app.state.notifications[0].comments_requested);
+        assert_eq!(
+            app.state.status_message.as_deref(),
+            Some("Loading comments for selected thread...")
+        );
+    }
+
+    #[test]
+    fn key_c_rejected_for_non_issue_or_pr() {
+        let mut app = App::new(Config::default());
+        let mut notification = test_notification("commit-1", true);
+        notification.subject.subject_type = NotificationType::Commit;
+        app.state.set_notifications(vec![notification]);
+
+        app.handle_normal_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(!app.state.notifications[0].comments_requested);
+        assert_eq!(
+            app.state.status_message.as_deref(),
+            Some("Comments are only supported for issues and pull requests")
+        );
+    }
 }
 
 impl Drop for App {
@@ -4337,6 +4420,9 @@ mod action_tests {
             author: None,
             context: None,
             event_body: None,
+            pr_comments: Vec::new(),
+            issue_comments: Vec::new(),
+            comments_requested: false,
         }
     }
 

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -233,6 +233,10 @@ impl HelpWidget {
                         desc: "Scroll preview (page)",
                     },
                     HelpLine {
+                        key: "c",
+                        desc: "Load comments for selected issue/PR",
+                    },
+                    HelpLine {
                         key: "1/2",
                         desc: "Focus pane 1 (list) / 2 (preview)",
                     },

--- a/src/workflow_runs.rs
+++ b/src/workflow_runs.rs
@@ -180,5 +180,8 @@ fn run_to_notification(
         author: None,
         context: None,
         event_body: None,
+        pr_comments: Vec::new(),
+        issue_comments: Vec::new(),
+        comments_requested: false,
     })
 }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Load issue/PR comments on keypress and append them to previews
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

This PR adds support for getting issue and PR comments upon a user keypress (currently `c`).

It's a fairly simple addition that adds:

- two new models, IssueComment and PullRequestComment
- two functions to get comments via the GitHub API in line with other requests
- pr_comments and issue_comments vectors to the relevant events, filter, hooks, etc
- a comments_requested flag on each relevant NotificationType to record previews which have had comments requested
- some tests to cover the basic cases (I'm sure I've missed some things here)

There are also some updates to the lockfile, so apologies if this adds too much noise.

I will admit that I am not an experienced Rust programmer, and this is my first PR anywhere for a Rust project, so I'd apologise in advance for any mistakes with formatting, linting, tests etc. I'd appreciate any feedback!

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add on-demand fetching of issue/PR comments via GitHub REST endpoints.
• Wire <b><i>c</i></b> key to request comment loading and revalidate the selected preview.
• Extend preview rendering to append fetched comments and add test coverage.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A(["TUI App (keypress)"]) --> B["Notification (state)"] --> C["PreviewManager (revalidate)"] --> D["PreviewFetcher"] --> E["GitHubClient REST"] --> F{{"GitHub API"}}
  D --> G["PreviewData body + comments"]

  subgraph Legend
    direction LR
    _ui(["UI / Interaction"]) ~~~ _mod["Module / Logic"] ~~~ _ext{{"External API"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Background fetch + cache per notification ID</b></summary>

- ➕ Avoids refetching comments when toggling previews or revisiting the same notification
- ➕ Can keep UI responsive by updating preview when the fetch completes
- ➖ Requires cache invalidation/expiry policy
- ➖ More concurrency/state complexity (in-flight requests, partial updates)

</details>

<details>
<summary><b>2. Use GraphQL to fetch preview + comments in a single query</b></summary>

- ➕ Fewer round trips (especially for PR: issue comments + review comments)
- ➕ More control over fields and pagination
- ➖ Adds GraphQL client/query maintenance overhead
- ➖ May require new auth scopes/handling and different error semantics

</details>

<details>
<summary><b>3. Persist comment-loading as a separate UI mode (toggle comments panel)</b></summary>

- ➕ Clearer UX distinction between preview content vs. comment thread
- ➕ Can support pagination/scrolling without inflating the body string
- ➖ Bigger UI change (layout, focus handling, rendering)
- ➖ More code to maintain compared to appending markdown text

</details>

**Recommendation:** The PR’s lazy-load-on-keypress approach is a good fit for minimizing API calls and keeping the change set contained. If reviewers see repeated network calls in practice, the next incremental step would be caching fetched comments per-notification (with simple TTL) while keeping the same `comments_requested` interaction model.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>rest.rs</strong> <code>Add REST client methods to fetch issue and PR comments</code> <code>+146/-1</code></summary>

<br/>

>Add REST client methods to fetch issue and PR comments
>
><pre>
>• Introduces get_issue_comments and get_pull_request_comments with parsing helpers. PR comment fetching merges issue comments and review comments, filters empty bodies, and sorts by created_at.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-e8f123c87d93048607cf2868ab9de50143d1badd10a2fb8c849d1ee1fd7573bb'>src/api/rest.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>events.rs</strong> <code>Initialize comment fields when converting events to notifications</code> <code>+3/-0</code></summary>

<br/>

>Initialize comment fields when converting events to notifications
>
><pre>
>• Ensures event-derived notifications start with empty comment vectors and comments_requested=false. Prevents uninitialized state in downstream preview/UI paths.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-59e0fecb904d610f27811d416aa3f26cc0d1bfed220ac69f8e18147f9bd68fd0'>src/events.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>notification.rs</strong> <code>Add IssueComment/PullRequestComment models and fields on Notification</code> <code>+32/-0</code></summary>

<br/>

>Add IssueComment/PullRequestComment models and fields on Notification
>
><pre>
>• Defines new comment model structs and adds pr_comments, issue_comments, and comments_requested to Notification. Fields are serde-skipped/defaulted to avoid affecting GitHub notifications deserialization.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-605b194478ebc6b9795ef60865aae430c80642bb5b9f312cccc7cd6318d13e94'>src/models/notification.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>preview.rs</strong> <code>Fetch and render comments in issue/PR previews (on demand)</code> <code>+122/-4</code></summary>

<br/>

>Fetch and render comments in issue/PR previews (on demand)
>
><pre>
>• Extends PreviewData to carry comment lists and updates issue/PR preview fetching to conditionally load comments only when comments_requested is true. Adds formatting helpers that append a &#x27;## Comments&#x27; section and tests for the issue formatting path.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-6650cb926fcaab52e46d5580416c1aee54ddea240b47f7a7c4f970e943e1cedb'>src/preview.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>app.rs</strong> <code>Bind &#x27;c&#x27; to request comment loading and trigger preview revalidation</code> <code>+86/-0</code></summary>

<br/>

>Bind &#x27;c&#x27; to request comment loading and trigger preview revalidation
>
><pre>
>• Adds request_comments_for_selected_notification to mark the selected Issue/PR notification as comments_requested, clear cached comments, and request preview revalidation. Updates key handling to call it on &#x27;c&#x27;, shows a loading preview message, and adds tests for supported/unsupported notification types.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-a58a4d41c31bafedecd6f4334ef43150f56cf416dd5a331d7d66b10c4b36ac81'>src/ui/app.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workflow_runs.rs</strong> <code>Initialize comment fields for workflow-run notifications</code> <code>+3/-0</code></summary>

<br/>

>Initialize comment fields for workflow-run notifications
>
><pre>
>• Ensures workflow-run derived notifications include empty comment vectors and comments_requested=false. Aligns all notification creation sites with the updated model.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-483292ef61c92a0b867903f422d7a32e8bfba5178b9e6a3c8cc767f89ad9ae53'>src/workflow_runs.rs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (5)</summary>

<blockquote>
<details>
<summary><strong>actions.rs</strong> <code>Update notification test fixtures for new comment fields</code> <code>+6/-0</code></summary>

<br/>

>Update notification test fixtures for new comment fields
>
><pre>
>• Extends test notification builders/fixtures to initialize pr_comments, issue_comments, and comments_requested. Ensures action-related tests compile and reflect the expanded Notification struct.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-ad9375f96c9eec1389952c2f1a9c2191b647d25a31079a38ea3b410ee1f6dfd4'>src/actions.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>filter.rs</strong> <code>Update filter test fixtures for new notification fields</code> <code>+3/-0</code></summary>

<br/>

>Update filter test fixtures for new notification fields
>
><pre>
>• Adds default initializers for the new comment-related fields in test notifications. Keeps filter tests aligned with the Notification struct.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-94c4ec4f5acf5bd713712003e0b0ece62186fa93a897a1a42f977496fc120514'>src/filter.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>hooks.rs</strong> <code>Update hooks test fixtures for new notification fields</code> <code>+3/-0</code></summary>

<br/>

>Update hooks test fixtures for new notification fields
>
><pre>
>• Extends test notifications used by hooks tests to include empty comment vectors and comments_requested=false. Maintains compilation and consistent defaults.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-899bcbd56696efca2a5e4e16bae25c24bc325b9849d561972ae53a19a899409c'>src/hooks.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>preview_manager.rs</strong> <code>Update preview manager test fixtures for new notification fields</code> <code>+3/-0</code></summary>

<br/>

>Update preview manager test fixtures for new notification fields
>
><pre>
>• Adjusts test notification construction to include comment vectors and comments_requested default. Ensures preview manager tests remain compatible with the expanded model.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-89a4926157a65e448f4114e069af1a994d3e7a519ae8b137619813559de4e476'>src/preview_manager.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>tree.rs</strong> <code>Update state tree test fixtures for new notification fields</code> <code>+3/-0</code></summary>

<br/>

>Update state tree test fixtures for new notification fields
>
><pre>
>• Extends test notification initialization with pr_comments/issue_comments/comments_requested defaults. Keeps state tree tests compiling after model changes.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-823c33c5cc3ed3f173bf1f5d32d58b9ff09fd18b369c915ade64679ead2e72e3'>src/state/tree.rs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>help.rs</strong> <code>Document &#x27;c&#x27; keybinding for loading comments</code> <code>+4/-0</code></summary>

<br/>

>Document &#x27;c&#x27; keybinding for loading comments
>
><pre>
>• Adds a help entry describing the new &#x27;c&#x27; shortcut to load comments for the selected issue/PR.
></pre>
>
><a href='https://github.com/chmouel/gh-news/pull/38/files#diff-c46b1df0b0db0930605c9231a12e020a442d849617d6c728995c5243cb6e8167'>src/ui/components/help.rs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>