### PR TITLE
feat: Add quick-merge support with rich pull request preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["github", "notifications", "tui", "cli", "ratatui"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-ratatui = "0.27"
+ratatui = { version = "0.27", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/README.md
+++ b/README.md
@@ -98,23 +98,18 @@ gh news --static-display | grep "something" # List notifications without TUI
 
 ### Actions
 
-- `Enter` - Open notification in browser and mark as read, or toggle repository collapse on headers
-- `o` - Open notification in browser without marking as read
+Multi-select first with `Space` (magenta checkmark); the actions below then apply to the whole selection instead of just the current notification.
+
+- `Enter` - Open in browser and mark as read, or toggle repository collapse on headers
+- `o` - Open in browser without marking as read
 - `O` - Open URL menu (open/copy/print) for the current selection
 - `.` - Toggle read/unread status
-- `d` - Archive (done) notification — removes from inbox
+- `d` - Archive (done), removing it from the inbox
+- `m` - Merge the previewed pull request (confirmation dialog; method set by `merge_method` in config, default squash)
 - `!` - Pin/unpin notification (pinned appear at top)
 - `h` - Collapse current repository
 - `x` - Open action menu (built-in and custom actions on notifications)
-
-### Multi-select
-
-- `Space` - Toggle selection on notification (magenta checkmark)
 - `Esc` - Clear selection (or quit if no selection)
-- `Enter` - Open all selected + mark as read
-- `o` - Open all selected without marking as read
-- `.` - Mark all selected as read
-- `d` - Archive all selected
 - `Ctrl+A` - Act on selected notifications, or on the current filtered list if none are selected
 - `Ctrl+Alt+A` - Toggle select all notifications in current repository
 
@@ -129,6 +124,7 @@ gh news --static-display | grep "something" # List notifications without TUI
 - `J`/`K` - Scroll preview (line by line)
 - `Shift+U`/`Shift+D` - Scroll preview (5 lines)
 - `Ctrl+U`/`Ctrl+D` - Scroll preview (page)
+- `c` - Expand/collapse pull request CI checks
 - `1`/`2` - Focus pane 1 (list) / pane 2 (preview)
 - `M` - Toggle auto-mark-read on/off (persisted across sessions)
 
@@ -150,100 +146,40 @@ gh-news can be configured via a TOML file at `~/.config/gh-news/config.toml`. Al
 
 ### Example Config
 
-See also the example config file [here](./config.example.toml).
+Full reference with every option and its default: [config.example.toml](./config.example.toml).
 
 ```toml
 # API & Network
 auto_refresh_interval = 120  # seconds, 0 to disable
-api_timeout = 30             # seconds
 max_notifications = 100      # limit notifications fetched
-pagination_size = 50         # notifications per API page
 
 # Default filters (same as CLI flags)
 show_read = false            # show read notifications (like --all)
-participating_only = false   # only participating (like --participating)
-default_filter = ""          # regex filter always applied (matched against: repo title type reason author)
-
-# Structured exclude filters
-exclude_types = ["CheckSuite"]           # by type: Issue, PR, Release, CheckSuite, etc.
-exclude_reasons = ["subscribed"]         # by reason: subscribed, ci_activity, etc.
-exclude_repos = ["noisy-org/*"]          # by repo: exact or glob pattern
-exclude_subjects = ["^Bump ", "\\[bot\\]"] # by title: regex patterns (case-insensitive)
+exclude_repos = ["noisy-org/*"]
 
 # Theme
-theme = "tokyo_night"            # see Themes section below for all options
-# [theme_colors]                 # override individual palette colours (hex)
-# blue = "#7aa2f7"
-
-# Display
-default_preview_mode = "vertical"    # "off", "horizontal", or "vertical"
-repos_collapsed = false              # start with repos collapsed
-org_grouping = "auto"               # "off", "auto", or "always"
-list_layout = "right_aligned"       # "right_aligned", "icon_only", or "two_line"
+theme = "tokyo_night"        # see Themes section below for all options
 
 # Behaviour
-auto_mark_read = false                # mark notifications read when navigating to them (disabled by default)
-auto_mark_read_delay_ms = 400        # dwell time (ms) before marking as read (only when auto_mark_read is enabled)
-auto_archive = false                 # archive notifications when navigating away (implies auto_mark_read)
-auto_mark_on_open = true             # mark notifications read when opening them in the browser
-
-# Notification cache (cached data is shown instantly on startup, then refreshed).
-# Preview details are also cached locally and reused until the notification changes.
-cache_file = ""              # custom cache path (default: ~/.cache/gh-news/notifications_cache.json)
-
-# External commands
-browser_command = ""         # custom browser, e.g. "firefox" (uses system default if empty)
-open_method = "builtin"      # how `o`/Enter delivers URLs: "builtin" (browser), "osc" (OSC 52 clipboard), "print" (suspend UI, print to stdout)
-
-# Notification hooks
-on_new_notification_command = ""  # command to run when new notifications appear
-
-# GitHub Enterprise (optional)
-github_host = "github.com"   # change for GHE, e.g. "github.mycompany.com"
-
-# GitHub Actions workflow notifications (opt-in)
-enable_actions = false       # set to true to show workflow run notifications
-actions_failed_only = true   # only show failed/cancelled runs (default when actions enabled)
-actions_repos = []           # repos to watch (empty = derive from your notifications)
-
-# GitHub Activity Events feed (opt-in)
-enable_events = false        # set to true to show activity events
-event_types = []             # filter event types, e.g. ["WatchEvent", "ForkEvent"] (empty = all)
-
-# Repository event watching (opt-in)
-watch_repos = []             # repos to watch for all events, e.g. ["owner/repo", "org/*"]
-                             # supports glob patterns; event_types filter applies here too
+auto_mark_read = false       # mark notifications read when navigating to them
 ```
 
 ### Themes
 
-gh-news ships with built-in colour themes. Set the `theme` key in your
-config to switch:
+gh-news ships with 21 built-in colour themes, both dark and light. Set the
+`theme` key in your config to switch:
 
 | Name | Style |
-|------|-------|
+| ------ | ------- |
 | `tokyo_night` (default) | Dark blue with soft white text |
 | `catppuccin_mocha` | Warm dark (Catppuccin dark variant) |
 | `catppuccin_latte` | Light (Catppuccin light variant) |
 | `nord` | Arctic blue-grey |
 | `dracula` | Dark with vivid accents |
 | `gruvbox_dark` | Retro warm colours |
-| `dracula_light` | Dracula light variant |
-| `narna` | Balanced dark theme with blue accents |
-| `clean_light` | Optimized for light terminal backgrounds |
-| `rose_pine_dawn` | Rosé Pine Dawn (Light) |
-| `one_light` | Atom One Light |
-| `everforest_light` | Everforest Light (Medium) |
-| `everforest_dark` | Everforest Dark (Medium) |
-| `one_dark` | One Dark |
-| `rose_pine` | Rosé Pine (Dark) |
-| `ayu_mirage` | Ayu Mirage |
-| `modern` | Sleek, modern dark theme with vibrant accents |
-| `kanagawa` | Kanagawa (Wave) |
-| `solarized_dark` | Solarized dark |
-| `solarized_light` | Solarized light |
-| `gruvbox_light` | Gruvbox light |
-| `monokai` | Monokai |
+
+See [config.example.toml](./config.example.toml) for the full list, including
+`one_light`, `rose_pine`, `solarized_dark`, `kanagawa`, `monokai`, and more.
 
 ```toml
 theme = "catppuccin_mocha"
@@ -263,15 +199,11 @@ red  = "#ff0000"
 Available colour fields: `bg`, `bg_dark`, `bg_highlight`, `fg`, `fg_muted`,
 `fg_dim`, `blue`, `cyan`, `green`, `yellow`, `red`, `magenta`, `orange`.
 
-#### Theme Screenshots
+#### Theme Screenshot
 
 **rose_pine_dawn**
 
 <img width="3730" height="2484" alt="rose_pine_dawn" src="https://github.com/user-attachments/assets/0179bf1c-1ef8-437b-86e7-60bdf993f423" />
-
-**one_light**
-
-<img width="3730" height="2484" alt="one_light" src="https://github.com/user-attachments/assets/9e7e5f22-a108-4262-9eab-7c5d1f7d2aff" />
 
 ### Notification Hooks
 
@@ -284,7 +216,7 @@ on_new_notification_command = "/path/to/your/script.sh"
 The command runs once per new notification with these environment variables:
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `GH_NEWS_ID` | Notification ID |
 | `GH_NEWS_TITLE` | Notification title |
 | `GH_NEWS_REPO` | Repository name |
@@ -295,20 +227,7 @@ The command runs once per new notification with these environment variables:
 | `GH_NEWS_UNREAD` | Read status (true/false) |
 | `GH_NEWS_UPDATED_AT` | ISO 8601 timestamp (if available) |
 
-**Example: Desktop notification (Linux)**
-
-```bash
-#!/bin/bash
-notify-send "GitHub: $GH_NEWS_TYPE" "$GH_NEWS_TITLE"
-```
-
-**Example: Sound alert**
-
-```toml
-on_new_notification_command = "paplay /usr/share/sounds/freedesktop/stereo/message.oga"
-```
-
-**Example: Conditional action**
+**Example: Notify only on review requests**
 
 ```bash
 #!/bin/bash
@@ -324,7 +243,7 @@ fi
 The action menu (press `x`) always includes these built-in actions:
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | Mute Thread | Sets the thread subscription to ignored via the GitHub API. Future notifications for the thread are suppressed until you comment or are `@mentioned` again. |
 | Mute Repository | Sets the repository subscription to ignored via the GitHub API. Suppresses all notifications from that repository. |
 | Snooze (4 hours) | Hides the notification until 4 hours from now. |
@@ -359,35 +278,20 @@ interactive = true  # Suspend TUI for interactive commands
 
 Actions support placeholder substitution:
 
-| Placeholder | Description |
-|-------------|-------------|
-| `{id}` | Notification ID |
-| `{title}` | Notification title |
-| `{number}` | PR/issue/discussion number (empty for other types) |
-| `{url}` | Web URL for the notification |
-| `{repo}` | Repository name (without owner) |
-| `{owner}` | Repository owner |
-| `{full_name}` | Full repository name (owner/repo) |
-| `{type}` | Notification type (Issue, PullRequest, etc.) |
-| `{reason}` | Notification reason (mention, review_requested, etc.) |
-| `{unread}` | Read status (true/false) |
+| Placeholder | Description | Plural form (batch, space-separated) |
+| ------------- | ------------- | ------------- |
+| `{id}` | Notification ID | `{ids}` |
+| `{title}` | Notification title | `{titles}` |
+| `{number}` | PR/issue/discussion number (empty for other types) | - |
+| `{url}` | Web URL for the notification | `{urls}` |
+| `{repo}` | Repository name (without owner) | `{repos}` |
+| `{owner}` | Repository owner | `{owners}` |
+| `{full_name}` | Full repository name (owner/repo) | `{full_names}` |
+| `{type}` | Notification type (Issue, PullRequest, etc.) | `{types}` |
+| `{reason}` | Notification reason (mention, review_requested, etc.) | `{reasons}` |
+| `{unread}` | Read status (true/false) | - |
 
-**Batch Placeholders (plural forms):**
-
-Use plural placeholders to run a single command with all selected notifications:
-
-| Placeholder | Description |
-|-------------|-------------|
-| `{ids}` | All notification IDs, space-separated |
-| `{titles}` | All notification titles, space-separated |
-| `{urls}` | All web URLs, space-separated |
-| `{repos}` | All repository names, space-separated |
-| `{owners}` | All repository owners, space-separated |
-| `{full_names}` | All full repository names, space-separated |
-| `{types}` | All notification types, space-separated |
-| `{reasons}` | All notification reasons, space-separated |
-
-Example batch action:
+Plural placeholders run the command once with all selected notifications instead of once per notification. Example:
 
 ```toml
 [[actions]]
@@ -401,14 +305,12 @@ When you select multiple notifications and run this action, it executes once as 
 **Action Options:**
 
 | Option | Default | Description |
-|--------|---------|-------------|
+| -------- | --------- | ------------- |
 | `name` | required | Display name in the action menu |
 | `command` | required | Command template with placeholders |
 | `priority` | unset | Lower numbers sort earlier in the action menu |
 | `interactive` | `false` | Suspend TUI and run command with full terminal access (for TUI tools like fzf, vim) |
 | `show_output` | `false` | Capture command output and display it in a scrollable TUI popup (incompatible with `interactive`) |
-
-With singular placeholders, the command runs once per selected notification. With plural placeholders (e.g., `{urls}`), it runs once with all values.
 
 ### Named Views
 
@@ -417,7 +319,7 @@ Named views are saved filter presets you can switch between instantly with `V`. 
 **Built-in views:**
 
 | View | What it shows |
-|------|---------------|
+| ------ | --------------- |
 | Participating | Everything except passive subscriptions and CI noise (`subscribed`, `ci_activity` reasons excluded) |
 | Mentions | Direct `@mention` and team mention notifications |
 | Review Requests | PRs where your review has been requested |
@@ -429,7 +331,7 @@ Named views are saved filter presets you can switch between instantly with `V`. 
 
 **Custom views:**
 
-Define your own in `config.toml` using `[[views]]` sections. All filter fields are optional — unset fields inherit from the global config defaults.
+Define your own in `config.toml` using `[[views]]` sections. All filter fields are optional; unset fields inherit from the global config defaults.
 
 ```toml
 [[views]]
@@ -450,7 +352,7 @@ filter = "dependabot"
 **View fields:**
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `name` | Display name shown in the picker (required) |
 | `filter` | Regex applied to `repo title type reason author` (author populated by background enrichment) |
 | `exclude_types` | Override global `exclude_types` for this view |
@@ -477,7 +379,7 @@ repos_collapsed = true
 **Session fields:**
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `name` | Display name shown in the session picker (required) |
 | `view` | Built-in or custom view name to activate |
 | `filter` | Extra regex filter layered on top of the selected view/default filter |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ GitHub notifications TUI built with Rust and ratatui.
 - Multi-select for batch operations on notifications
 - Auto-refresh with configurable interval
 - Preview notifications with rich details (GraphQL-powered for Issues, PRs, Discussions, Commits)
+- Quick-merge pull requests straight from the preview (`m`, with confirmation)
 - When a notification is triggered by a comment, the preview shows that comment instead of the issue/PR description
 - Persisted preview cache for faster repeated detail views
 - Regex filtering to filter specific notifications

--- a/config.example.toml
+++ b/config.example.toml
@@ -184,6 +184,10 @@ auto_mark_read_delay_ms = 400
 #       and saved to state file.
 auto_archive = false
 
+# Merge method used by the quick-merge action (m key on a pull request
+# preview). One of: "merge", "squash", "rebase". Default: "squash"
+merge_method = "squash"
+
 # ==============================================================================
 # EXTERNAL COMMANDS & HOOKS
 # ==============================================================================

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -312,6 +312,68 @@ impl GitHubClient {
         self.send_no_content(self.client.delete(&url))
     }
 
+    /// Merge a pull request.  `head_sha` guards against merging commits
+    /// pushed after the user confirmed.  Returns GitHub's response message.
+    pub fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        merge_method: &str,
+        head_sha: &str,
+    ) -> Result<String> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}/merge",
+            self.api_base, owner, repo, number
+        );
+        let mut body = serde_json::json!({ "merge_method": merge_method });
+        if !head_sha.is_empty() {
+            body["sha"] = serde_json::Value::String(head_sha.to_string());
+        }
+
+        let request = self.client.put(&url).json(&body);
+        let response = self.client.execute(request.build().map_err(Error::from)?);
+        let response = response.map_err(Error::from)?;
+        self.record_rate_limit_headers(response.headers());
+        let status = response.status();
+        let bytes = response.bytes().map_err(Error::from)?.to_vec();
+        let value: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        // GitHub explains refusals (403/405/409/422) in `message`.
+        let message = value
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        if !status.is_success() {
+            return Err(ApiError::HttpStatus {
+                status: status.as_u16(),
+                message: if message.is_empty() {
+                    "Merge failed".to_string()
+                } else {
+                    message
+                },
+            }
+            .into());
+        }
+        let merged = value
+            .get("merged")
+            .and_then(|m| m.as_bool())
+            .unwrap_or(false);
+        if !merged {
+            return Err(ApiError::HttpStatus {
+                status: status.as_u16(),
+                message: if message.is_empty() {
+                    "Pull request was not merged".to_string()
+                } else {
+                    message
+                },
+            }
+            .into());
+        }
+        Ok(message)
+    }
+
     pub fn get_vulnerability_alert_by_url(&self, url: &str) -> Result<Value> {
         self.get_json(url)
     }
@@ -643,6 +705,58 @@ mod tests {
             client.rate_limit_status().and_then(|s| s.remaining),
             Some(4998)
         );
+
+        server.join();
+    }
+
+    #[test]
+    fn merge_pull_request_returns_message_on_success() {
+        let server = spawn_json_server(vec![(
+            "/repos/owner/repo/pulls/7/merge".to_string(),
+            200,
+            r#"{"merged":true,"message":"Pull Request successfully merged","sha":"abc"}"#
+                .to_string(),
+        )]);
+        let client = GitHubClient::new_test_with_base(server.base_url.clone());
+
+        let message = client
+            .merge_pull_request("owner", "repo", 7, "squash", "abc123")
+            .unwrap();
+        assert_eq!(message, "Pull Request successfully merged");
+
+        server.join();
+    }
+
+    #[test]
+    fn merge_pull_request_surfaces_github_error_message() {
+        let server = spawn_json_server(vec![(
+            "/repos/owner/repo/pulls/7/merge".to_string(),
+            405,
+            r#"{"message":"Pull Request is not mergeable"}"#.to_string(),
+        )]);
+        let client = GitHubClient::new_test_with_base(server.base_url.clone());
+
+        let err = client
+            .merge_pull_request("owner", "repo", 7, "squash", "abc123")
+            .unwrap_err();
+        assert!(err.to_string().contains("Pull Request is not mergeable"));
+
+        server.join();
+    }
+
+    #[test]
+    fn merge_pull_request_rejects_unmerged_success_response() {
+        let server = spawn_json_server(vec![(
+            "/repos/owner/repo/pulls/7/merge".to_string(),
+            200,
+            r#"{"merged":false,"message":"Queued for merge"}"#.to_string(),
+        )]);
+        let client = GitHubClient::new_test_with_base(server.base_url.clone());
+
+        let err = client
+            .merge_pull_request("owner", "repo", 7, "merge", "abc123")
+            .unwrap_err();
+        assert!(err.to_string().contains("Queued for merge"));
 
         server.join();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,27 @@ pub enum OpenMethod {
     Print,
 }
 
+/// Merge method for the quick-merge pull request action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeMethod {
+    Merge,
+    #[default]
+    Squash,
+    Rebase,
+}
+
+impl MergeMethod {
+    /// Value for the REST merge API's `merge_method` field.
+    pub fn api_value(self) -> &'static str {
+        match self {
+            MergeMethod::Merge => "merge",
+            MergeMethod::Squash => "squash",
+            MergeMethod::Rebase => "rebase",
+        }
+    }
+}
+
 /// Layout mode for the notification list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -175,6 +196,10 @@ pub struct Config {
     pub auto_archive: bool,
     pub auto_mark_on_open: bool,
 
+    /// Merge method used by the quick-merge action (merge|squash|rebase).
+    #[serde(default)]
+    pub merge_method: MergeMethod,
+
     // External commands
     pub browser_command: Option<String>,
     pub open_method: OpenMethod,
@@ -268,6 +293,7 @@ impl Default for Config {
             auto_mark_read_delay_ms: 400,
             auto_archive: false,
             auto_mark_on_open: true,
+            merge_method: MergeMethod::default(),
             cache_file: None,
             browser_command: None,
             open_method: OpenMethod::default(),

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -13,6 +13,39 @@ pub struct LatestComment {
     pub created_at: String,
 }
 
+/// A single CI check (check run or commit status), normalised to one state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiCheck {
+    pub name: String,
+    /// Normalised uppercase state: SUCCESS, FAILURE, ERROR, PENDING,
+    /// IN_PROGRESS, QUEUED, CANCELLED, TIMED_OUT, ACTION_REQUIRED,
+    /// NEUTRAL, SKIPPED, STALE, EXPECTED…
+    pub state: String,
+}
+
+/// Kind of pull-request timeline activity shown in the preview feed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimelineKind {
+    Comment,
+    Approved,
+    ChangesRequested,
+    Commented,
+    Dismissed,
+}
+
+/// A comment or review event on a pull request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEntry {
+    pub author: String,
+    pub kind: TimelineKind,
+    pub body: String,
+    /// RFC 3339 timestamp (reviews use their submission time).
+    pub timestamp: String,
+}
+
+// Previews are allocated one at a time, so the size gap between the rich
+// pull-request variant and the others is harmless.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PreviewData {
     PullRequest {
@@ -32,6 +65,22 @@ pub enum PreviewData {
         changed_files: u64,
         #[serde(default)]
         latest_comment: Option<LatestComment>,
+        #[serde(default)]
+        ci_checks: Vec<CiCheck>,
+        #[serde(default)]
+        ci_total_count: u64,
+        #[serde(default)]
+        merge_state_status: String,
+        #[serde(default)]
+        head_ref_oid: String,
+        #[serde(default)]
+        base_ref: String,
+        #[serde(default)]
+        head_ref: String,
+        #[serde(default)]
+        timeline: Vec<TimelineEntry>,
+        #[serde(default)]
+        timeline_total_count: u64,
     },
     Issue {
         number: String,
@@ -851,7 +900,71 @@ impl PreviewFetcher {
             .parse()
             .map_err(|_| crate::error::Error::Config("Invalid PR number".to_string()))?;
 
-        let query = r#"
+        // Rich query: per-check CI contexts, merge state, head SHA and a
+        // recent-activity timeline.  Older GHES schemas may reject some
+        // fields, in which case we retry once with the baseline query.
+        let rich_query = r#"
+            query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                        number
+                        title
+                        body
+                        state
+                        merged
+                        isDraft
+                        mergeable
+                        mergeStateStatus
+                        reviewDecision
+                        additions
+                        deletions
+                        changedFiles
+                        headRefOid
+                        baseRefName
+                        headRefName
+                        author { login }
+                        comments { totalCount }
+                        labels(first: 10) { nodes { name } }
+                        commits(last: 1) {
+                            nodes {
+                                commit {
+                                    statusCheckRollup {
+                                        state
+                                        contexts(first: 100) {
+                                            totalCount
+                                            nodes {
+                                                __typename
+                                                ... on CheckRun { name status conclusion }
+                                                ... on StatusContext { context state }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        timelineItems(last: 30, itemTypes: [ISSUE_COMMENT, PULL_REQUEST_REVIEW]) {
+                            totalCount
+                            nodes {
+                                __typename
+                                ... on IssueComment {
+                                    author { login }
+                                    body
+                                    createdAt
+                                }
+                                ... on PullRequestReview {
+                                    author { login }
+                                    body
+                                    state
+                                    submittedAt
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        "#;
+
+        let baseline_query = r#"
             query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                     pullRequest(number: $number) {
@@ -887,7 +1000,11 @@ impl PreviewFetcher {
             "number": pr_num,
         });
 
-        let data = client.graphql(query, variables)?;
+        let data = match client.graphql(rich_query, variables.clone()) {
+            Ok(data) => data,
+            // Older GHES: retry once with the baseline query.
+            Err(_) => client.graphql(baseline_query, variables)?,
+        };
 
         let pr = data
             .get("repository")
@@ -897,6 +1014,148 @@ impl PreviewFetcher {
                 crate::error::Error::Config("Pull request not found in response".to_string())
             })?;
 
+        Ok(Self::parse_pr_response(pr, number))
+    }
+
+    /// Normalise a CheckRun / StatusContext node to a single uppercase state.
+    fn normalise_check_state(node: &serde_json::Value) -> String {
+        if node.get("__typename").and_then(|v| v.as_str()) == Some("StatusContext") {
+            return node
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("PENDING")
+                .to_uppercase();
+        }
+        // CheckRun: conclusion is null while running; fall back to status.
+        match node.get("conclusion").and_then(|v| v.as_str()) {
+            Some(conclusion) => conclusion.to_uppercase(),
+            None => node
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("PENDING")
+                .to_uppercase(),
+        }
+    }
+
+    fn parse_ci_checks(pr: &serde_json::Value) -> (Vec<CiCheck>, u64) {
+        let Some(contexts) = pr
+            .get("commits")
+            .and_then(|v| v.get("nodes"))
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|n| n.get("commit"))
+            .and_then(|c| c.get("statusCheckRollup"))
+            .and_then(|s| s.get("contexts"))
+        else {
+            return (Vec::new(), 0);
+        };
+
+        let total = contexts
+            .get("totalCount")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let checks = contexts
+            .get("nodes")
+            .and_then(|v| v.as_array())
+            .map(|nodes| {
+                nodes
+                    .iter()
+                    .map(|node| {
+                        let name = node
+                            .get("name")
+                            .or_else(|| node.get("context"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unnamed check")
+                            .to_string();
+                        CiCheck {
+                            name,
+                            state: Self::normalise_check_state(node),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        (checks, total)
+    }
+
+    fn parse_timeline(pr: &serde_json::Value) -> (Vec<TimelineEntry>, u64) {
+        let Some(items) = pr.get("timelineItems") else {
+            return (Vec::new(), 0);
+        };
+
+        let total = items
+            .get("totalCount")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let entries = items
+            .get("nodes")
+            .and_then(|v| v.as_array())
+            .map(|nodes| {
+                nodes
+                    .iter()
+                    .filter_map(|node| {
+                        let author = node
+                            .get("author")
+                            .and_then(|a| a.get("login"))
+                            .and_then(|l| l.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let body = node
+                            .get("body")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string();
+                        match node.get("__typename").and_then(|v| v.as_str()) {
+                            Some("IssueComment") => {
+                                if body.is_empty() {
+                                    return None;
+                                }
+                                Some(TimelineEntry {
+                                    author,
+                                    kind: TimelineKind::Comment,
+                                    body,
+                                    timestamp: node
+                                        .get("createdAt")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                })
+                            }
+                            Some("PullRequestReview") => {
+                                let kind = match node.get("state").and_then(|v| v.as_str()) {
+                                    Some("APPROVED") => TimelineKind::Approved,
+                                    Some("CHANGES_REQUESTED") => TimelineKind::ChangesRequested,
+                                    Some("DISMISSED") => TimelineKind::Dismissed,
+                                    Some("COMMENTED") => TimelineKind::Commented,
+                                    // PENDING (draft) reviews are not activity yet.
+                                    _ => return None,
+                                };
+                                // Skip empty COMMENTED reviews (inline-only review shells).
+                                if body.is_empty() && kind == TimelineKind::Commented {
+                                    return None;
+                                }
+                                Some(TimelineEntry {
+                                    author,
+                                    kind,
+                                    body,
+                                    timestamp: node
+                                        .get("submittedAt")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                })
+                            }
+                            _ => None,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        (entries, total)
+    }
+
+    fn parse_pr_response(pr: &serde_json::Value, number: String) -> PreviewData {
         let title = pr
             .get("title")
             .and_then(|v| v.as_str())
@@ -922,6 +1181,26 @@ impl PreviewFetcher {
             Some("CONFLICTING") => "No".to_string(),
             _ => "Unknown".to_string(),
         };
+        let merge_state_status = pr
+            .get("mergeStateStatus")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let head_ref_oid = pr
+            .get("headRefOid")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let base_ref = pr
+            .get("baseRefName")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let head_ref = pr
+            .get("headRefName")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
         let review_decision = pr
             .get("reviewDecision")
             .and_then(|v| v.as_str())
@@ -941,6 +1220,7 @@ impl PreviewFetcher {
         let additions = pr.get("additions").and_then(|v| v.as_u64()).unwrap_or(0);
         let deletions = pr.get("deletions").and_then(|v| v.as_u64()).unwrap_or(0);
         let changed_files = pr.get("changedFiles").and_then(|v| v.as_u64()).unwrap_or(0);
+        // Server-side aggregate: authoritative even when contexts are truncated.
         let ci_status = pr
             .get("commits")
             .and_then(|v| v.get("nodes"))
@@ -952,9 +1232,11 @@ impl PreviewFetcher {
             .and_then(|v| v.as_str())
             .unwrap_or("UNKNOWN")
             .to_string();
+        let (ci_checks, ci_total_count) = Self::parse_ci_checks(pr);
+        let (timeline, timeline_total_count) = Self::parse_timeline(pr);
         let labels = extract_label_names(pr);
 
-        Ok(PreviewData::PullRequest {
+        PreviewData::PullRequest {
             number,
             title,
             state,
@@ -970,7 +1252,15 @@ impl PreviewFetcher {
             deletions,
             changed_files,
             latest_comment: None,
-        })
+            ci_checks,
+            ci_total_count,
+            merge_state_status,
+            head_ref_oid,
+            base_ref,
+            head_ref,
+            timeline,
+            timeline_total_count,
+        }
     }
 
     fn fetch_commit_preview(client: &GitHubClient, repo: &str, sha: &str) -> Result<PreviewData> {
@@ -1614,57 +1904,36 @@ mod tests {
 
     #[test]
     fn test_preview_view_displays_draft_only_for_open_pull_requests() {
-        let open_draft = PreviewData::PullRequest {
-            number: "1".to_string(),
-            title: "Open draft".to_string(),
-            state: "open".to_string(),
-            author: "octocat".to_string(),
-            comments: 0,
-            mergeable: "Unknown".to_string(),
-            body: String::new(),
-            labels: Vec::new(),
-            review_decision: "NONE".to_string(),
-            is_draft: true,
-            ci_status: "UNKNOWN".to_string(),
-            additions: 0,
-            deletions: 0,
-            changed_files: 0,
-            latest_comment: None,
-        };
-        let closed_draft = PreviewData::PullRequest {
-            number: "2".to_string(),
-            title: "Closed draft".to_string(),
-            state: "closed".to_string(),
-            author: "octocat".to_string(),
-            comments: 0,
-            mergeable: "Unknown".to_string(),
-            body: String::new(),
-            labels: Vec::new(),
-            review_decision: "NONE".to_string(),
-            is_draft: true,
-            ci_status: "UNKNOWN".to_string(),
-            additions: 0,
-            deletions: 0,
-            changed_files: 0,
-            latest_comment: None,
-        };
-        let merged_draft = PreviewData::PullRequest {
-            number: "3".to_string(),
-            title: "Merged draft".to_string(),
-            state: "merged".to_string(),
-            author: "octocat".to_string(),
-            comments: 0,
-            mergeable: "Unknown".to_string(),
-            body: String::new(),
-            labels: Vec::new(),
-            review_decision: "NONE".to_string(),
-            is_draft: true,
-            ci_status: "UNKNOWN".to_string(),
-            additions: 0,
-            deletions: 0,
-            changed_files: 0,
-            latest_comment: None,
-        };
+        fn draft_pr(number: &str, title: &str, state: &str) -> PreviewData {
+            PreviewData::PullRequest {
+                number: number.to_string(),
+                title: title.to_string(),
+                state: state.to_string(),
+                author: "octocat".to_string(),
+                comments: 0,
+                mergeable: "Unknown".to_string(),
+                body: String::new(),
+                labels: Vec::new(),
+                review_decision: "NONE".to_string(),
+                is_draft: true,
+                ci_status: "UNKNOWN".to_string(),
+                additions: 0,
+                deletions: 0,
+                changed_files: 0,
+                latest_comment: None,
+                ci_checks: Vec::new(),
+                ci_total_count: 0,
+                merge_state_status: String::new(),
+                head_ref_oid: String::new(),
+                base_ref: String::new(),
+                head_ref: String::new(),
+                timeline: Vec::new(),
+                timeline_total_count: 0,
+            }
+        }
+        let open_draft = draft_pr("1", "Open draft", "open");
+        let closed_draft = draft_pr("2", "Closed draft", "closed");
+        let merged_draft = draft_pr("3", "Merged draft", "merged");
 
         let open_header = PreviewView::from(&open_draft).header[0].text();
         let closed_header = PreviewView::from(&closed_draft).header[0].text();
@@ -1673,6 +1942,165 @@ mod tests {
         assert!(open_header.ends_with("[draft]"));
         assert!(closed_header.ends_with("[closed]"));
         assert!(merged_header.ends_with("[merged]"));
+    }
+
+    #[test]
+    fn parse_pr_response_extracts_rich_fields() {
+        let pr = json!({
+            "title": "Add pills",
+            "body": "The description",
+            "state": "OPEN",
+            "merged": false,
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": "APPROVED",
+            "additions": 12,
+            "deletions": 4,
+            "changedFiles": 3,
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "headRefName": "feature",
+            "author": { "login": "octocat" },
+            "comments": { "totalCount": 2 },
+            "labels": { "nodes": [{ "name": "bug" }] },
+            "commits": { "nodes": [{ "commit": { "statusCheckRollup": {
+                "state": "SUCCESS",
+                "contexts": {
+                    "totalCount": 3,
+                    "nodes": [
+                        { "__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS" },
+                        { "__typename": "CheckRun", "name": "tests", "status": "IN_PROGRESS", "conclusion": null },
+                        { "__typename": "StatusContext", "context": "ci/legacy", "state": "FAILURE" }
+                    ]
+                }
+            }}}]},
+            "timelineItems": {
+                "totalCount": 2,
+                "nodes": [
+                    { "__typename": "IssueComment", "author": { "login": "alice" },
+                      "body": "Nice one", "createdAt": "2026-07-01T10:00:00Z" },
+                    { "__typename": "PullRequestReview", "author": { "login": "bob" },
+                      "body": "", "state": "APPROVED", "submittedAt": "2026-07-01T11:00:00Z" }
+                ]
+            }
+        });
+
+        let data = PreviewFetcher::parse_pr_response(&pr, "42".to_string());
+        match data {
+            PreviewData::PullRequest {
+                merge_state_status,
+                head_ref_oid,
+                base_ref,
+                head_ref,
+                ci_status,
+                ci_checks,
+                ci_total_count,
+                timeline,
+                timeline_total_count,
+                ..
+            } => {
+                assert_eq!(merge_state_status, "CLEAN");
+                assert_eq!(head_ref_oid, "abc123");
+                assert_eq!(base_ref, "main");
+                assert_eq!(head_ref, "feature");
+                assert_eq!(ci_status, "SUCCESS");
+                assert_eq!(ci_total_count, 3);
+                assert_eq!(ci_checks.len(), 3);
+                assert_eq!(ci_checks[0].name, "lint");
+                assert_eq!(ci_checks[0].state, "SUCCESS");
+                // Null conclusion falls back to status.
+                assert_eq!(ci_checks[1].state, "IN_PROGRESS");
+                assert_eq!(ci_checks[2].name, "ci/legacy");
+                assert_eq!(ci_checks[2].state, "FAILURE");
+                assert_eq!(timeline_total_count, 2);
+                assert_eq!(timeline.len(), 2);
+                assert_eq!(timeline[0].author, "alice");
+                assert_eq!(timeline[0].kind, TimelineKind::Comment);
+                assert_eq!(timeline[1].kind, TimelineKind::Approved);
+                assert_eq!(timeline[1].timestamp, "2026-07-01T11:00:00Z");
+            }
+            _ => panic!("Expected PreviewData::PullRequest"),
+        }
+    }
+
+    #[test]
+    fn parse_pr_response_handles_baseline_shape() {
+        // Baseline GHES fallback: no rich fields at all.
+        let pr = json!({
+            "title": "Old server",
+            "body": "b",
+            "state": "OPEN",
+            "merged": false,
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": null,
+            "author": { "login": "octocat" },
+            "comments": { "totalCount": 0 },
+            "commits": { "nodes": [{ "commit": { "statusCheckRollup": { "state": "PENDING" } } }] }
+        });
+
+        let data = PreviewFetcher::parse_pr_response(&pr, "1".to_string());
+        match data {
+            PreviewData::PullRequest {
+                ci_status,
+                ci_checks,
+                merge_state_status,
+                head_ref_oid,
+                timeline,
+                ..
+            } => {
+                assert_eq!(ci_status, "PENDING");
+                assert!(ci_checks.is_empty());
+                assert!(merge_state_status.is_empty());
+                assert!(head_ref_oid.is_empty());
+                assert!(timeline.is_empty());
+            }
+            _ => panic!("Expected PreviewData::PullRequest"),
+        }
+    }
+
+    #[test]
+    fn parse_timeline_skips_pending_reviews_and_empty_comments() {
+        let pr = json!({
+            "timelineItems": {
+                "totalCount": 3,
+                "nodes": [
+                    { "__typename": "PullRequestReview", "author": { "login": "a" },
+                      "body": "wip", "state": "PENDING", "submittedAt": null },
+                    { "__typename": "PullRequestReview", "author": { "login": "b" },
+                      "body": "", "state": "COMMENTED", "submittedAt": "2026-07-01T09:00:00Z" },
+                    { "__typename": "IssueComment", "author": { "login": "c" },
+                      "body": "   ", "createdAt": "2026-07-01T09:30:00Z" }
+                ]
+            }
+        });
+        let (entries, total) = PreviewFetcher::parse_timeline(&pr);
+        assert_eq!(total, 3);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn deserialises_cached_pr_preview_without_new_fields() {
+        // Persisted preview caches written before the redesign must still load.
+        let json = r#"{"PullRequest":{"number":"1","title":"t","state":"open",
+            "author":"a","comments":0,"mergeable":"Yes","body":"b","labels":[],
+            "review_decision":"NONE","is_draft":false,"ci_status":"SUCCESS",
+            "additions":1,"deletions":1,"changed_files":1}}"#;
+        let preview: PreviewData = serde_json::from_str(json).unwrap();
+        match preview {
+            PreviewData::PullRequest {
+                ci_checks,
+                timeline,
+                merge_state_status,
+                ..
+            } => {
+                assert!(ci_checks.is_empty());
+                assert!(timeline.is_empty());
+                assert!(merge_state_status.is_empty());
+            }
+            _ => panic!("Expected PreviewData::PullRequest"),
+        }
     }
 
     fn issue_preview_with_comment(latest_comment: Option<LatestComment>) -> PreviewData {

--- a/src/preview_manager.rs
+++ b/src/preview_manager.rs
@@ -1,7 +1,7 @@
 use crate::api::GitHubClient;
 use crate::models::Notification;
 use crate::preview::{PreviewData, PreviewFetcher};
-use crate::state_file::PersistedPreviewCacheEntry;
+use crate::state_file::{PersistedPreviewCacheEntry, PREVIEW_CACHE_SCHEMA_VERSION};
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -18,6 +18,16 @@ pub const PRIORITY_LOW: u8 = 1;
 struct CachedPreview {
     data: PreviewData,
     updated_at: Option<DateTime<Utc>>,
+    /// Preview-cache schema version this entry was written with.
+    schema_version: u32,
+}
+
+impl CachedPreview {
+    /// Entries written before the current schema lack newer fields and must
+    /// be revalidated in the background.
+    fn is_outdated_schema(&self) -> bool {
+        self.schema_version < PREVIEW_CACHE_SCHEMA_VERSION
+    }
 }
 
 /// Freshness status of a cached preview relative to the current notification state.
@@ -189,6 +199,7 @@ fn preview_worker_thread(
                 CachedPreview {
                     data,
                     updated_at: notification_updated_at,
+                    schema_version: PREVIEW_CACHE_SCHEMA_VERSION,
                 },
             );
             if should_persist {
@@ -217,6 +228,7 @@ fn load_persisted_cache() -> HashMap<String, CachedPreview> {
                 CachedPreview {
                     data: entry.data,
                     updated_at: entry.updated_at,
+                    schema_version: entry.schema_version,
                 },
             )
         })
@@ -232,6 +244,7 @@ fn persist_cache_snapshot(cache: &HashMap<String, CachedPreview>) {
                 PersistedPreviewCacheEntry {
                     data: cached.data.clone(),
                     updated_at: cached.updated_at,
+                    schema_version: cached.schema_version,
                 },
             )
         })
@@ -295,12 +308,13 @@ impl PreviewManager {
         match cache.get(&cache_key) {
             None => CacheStatus::Miss,
             Some(cached) => {
-                let is_stale = notification.preview_is_dynamic()
-                    && match (notification.updated_at, cached.updated_at) {
-                        (Some(new_ts), Some(old_ts)) => new_ts > old_ts,
-                        (Some(_), None) => true,
-                        _ => false,
-                    };
+                let is_stale = cached.is_outdated_schema()
+                    || (notification.preview_is_dynamic()
+                        && match (notification.updated_at, cached.updated_at) {
+                            (Some(new_ts), Some(old_ts)) => new_ts > old_ts,
+                            (Some(_), None) => true,
+                            _ => false,
+                        });
                 if is_stale {
                     CacheStatus::Stale(cached.data.clone())
                 } else {
@@ -381,12 +395,13 @@ impl PreviewManager {
         for notification in notifications {
             let cache_key = notification.preview_cache_key();
             if let Some(cached) = cache.get(&cache_key) {
-                let is_stale = notification.preview_is_dynamic()
-                    && match (notification.updated_at, cached.updated_at) {
-                        (Some(new_ts), Some(old_ts)) => new_ts > old_ts,
-                        (Some(_), None) => true,
-                        _ => false,
-                    };
+                let is_stale = cached.is_outdated_schema()
+                    || (notification.preview_is_dynamic()
+                        && match (notification.updated_at, cached.updated_at) {
+                            (Some(new_ts), Some(old_ts)) => new_ts > old_ts,
+                            (Some(_), None) => true,
+                            _ => false,
+                        });
                 if is_stale {
                     let entry = gen_lock.entry(cache_key.clone()).or_insert(0);
                     *entry += 1;
@@ -515,6 +530,7 @@ mod tests {
                 body: "b".into(),
             },
             updated_at,
+            schema_version: PREVIEW_CACHE_SCHEMA_VERSION,
         }
     }
 
@@ -545,6 +561,19 @@ mod tests {
         assert!(matches!(
             pm.get_cached_status(&notif),
             CacheStatus::Fresh(_)
+        ));
+    }
+
+    #[test]
+    fn outdated_schema_entry_is_reported_stale() {
+        let old = ts(2024, 1, 1);
+        let notif = make_notification("42", Some(old));
+        let mut cached = make_cached(Some(old));
+        cached.schema_version = PREVIEW_CACHE_SCHEMA_VERSION - 1;
+        let pm = manager_with_cache(vec![(&notif.preview_cache_key(), cached)]);
+        assert!(matches!(
+            pm.get_cached_status(&notif),
+            CacheStatus::Stale(_)
         ));
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -52,6 +52,12 @@ pub struct AppState {
     pub focused_pane: PaneFocus,
     pub show_help: bool,
     pub preview_content: Option<PreviewData>,
+    /// Cache key of the notification `preview_content` belongs to, so that
+    /// actions such as quick-merge never act on a stale preview.
+    pub preview_content_key: Option<String>,
+    /// Bumped on every `preview_content` change; used as a cheap render-cache
+    /// signature instead of hashing or debug-formatting the whole preview.
+    pub preview_content_version: u64,
     pub preview_scroll: usize,
     pub help_scroll: usize,
     pub help_search_query: String,
@@ -185,6 +191,8 @@ impl AppState {
             focused_pane: PaneFocus::None,
             show_help: false,
             preview_content: None,
+            preview_content_key: None,
+            preview_content_version: 0,
             preview_scroll: 0,
             help_scroll: 0,
             help_search_query: String::new(),
@@ -547,6 +555,14 @@ impl AppState {
 
     pub fn show_preview(&self) -> bool {
         self.preview_mode != PreviewMode::Off && !self.notifications.is_empty()
+    }
+
+    /// Replace the preview pane content, keeping the owning-notification key
+    /// and the render-cache version in sync.
+    pub fn set_preview_content(&mut self, content: Option<PreviewData>, key: Option<String>) {
+        self.preview_content = content;
+        self.preview_content_key = key;
+        self.preview_content_version = self.preview_content_version.wrapping_add(1);
     }
 
     pub fn mark_notification_read(&mut self, notification_id: &str) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -80,6 +80,9 @@ pub struct AppState {
     pub url_menu_index: usize,
     // Cached snoozed notification IDs — refreshed on fetch and after snooze/mute actions
     pub snoozed_ids: HashMap<String, SnoozeEntry>,
+    /// Per-thread local read timestamps driving the "new since last read"
+    /// PR preview feed (GitHub's last_read_at ignores local mark-reads).
+    pub local_read_cutoffs: HashMap<String, chrono::DateTime<chrono::Utc>>,
     // Captured output from a show_output action
     pub command_output: Option<CommandOutputData>,
     // Named view presets (cloned from config at startup)
@@ -148,10 +151,23 @@ pub enum MarkAllOption {
     MarkReadAndArchive, // Mark as read AND archive (done)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfirmAction {
-    MarkAllRead { selected: MarkAllOption },
-    ArchiveSelected { count: usize, option: MarkAllOption },
+    MarkAllRead {
+        selected: MarkAllOption,
+    },
+    ArchiveSelected {
+        count: usize,
+        option: MarkAllOption,
+    },
+    MergePullRequest {
+        notification_id: String,
+        repo: String,
+        number: u64,
+        title: String,
+        method: crate::config::MergeMethod,
+        head_sha: String,
+    },
 }
 
 impl AppState {
@@ -188,6 +204,8 @@ impl AppState {
             action_menu_index: 0,
             url_menu_index: 0,
             snoozed_ids: HashMap::new(),
+            local_read_cutoffs: crate::state_file::AppStateFile::load_read_cutoffs()
+                .unwrap_or_default(),
             command_output: None,
             views: Vec::new(),
             sessions: Vec::new(),
@@ -538,7 +556,47 @@ impl AppState {
             .find(|n| n.id == notification_id)
         {
             notif.unread = false;
+            self.record_read_cutoff(notification_id);
             self.note_notification_mutation();
+        }
+    }
+
+    /// Record the current time as the local read cutoff for a thread.
+    pub fn record_read_cutoff(&mut self, notification_id: &str) {
+        let now = chrono::Utc::now();
+        self.local_read_cutoffs
+            .insert(notification_id.to_string(), now);
+        let _ = crate::state_file::AppStateFile::save_read_cutoff(notification_id, now);
+    }
+
+    /// Record one shared cutoff for a successfully completed batch operation.
+    pub fn record_read_cutoffs(&mut self, notification_ids: &[String]) {
+        if notification_ids.is_empty() {
+            return;
+        }
+        let now = chrono::Utc::now();
+        for notification_id in notification_ids {
+            self.local_read_cutoffs.insert(notification_id.clone(), now);
+        }
+        let _ = crate::state_file::AppStateFile::save_read_cutoffs(notification_ids, now);
+    }
+
+    fn clear_read_cutoff(&mut self, notification_id: &str) {
+        if self.local_read_cutoffs.remove(notification_id).is_some() {
+            let _ = crate::state_file::AppStateFile::remove_read_cutoff(notification_id);
+        }
+    }
+
+    /// The boundary for the "new since last read" preview feed: the later of
+    /// GitHub's `last_read_at` and any local read timestamp.
+    pub fn effective_read_cutoff(
+        &self,
+        notification: &Notification,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        let local = self.local_read_cutoffs.get(&notification.id).copied();
+        match (notification.last_read_at, local) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
         }
     }
 
@@ -550,6 +608,13 @@ impl AppState {
         {
             notif.unread = !notif.unread;
             let unread = notif.unread;
+            if unread {
+                // Marked unread (or a failed mark-read was reverted): the
+                // thread's activity should count as new again.
+                self.clear_read_cutoff(notification_id);
+            } else {
+                self.record_read_cutoff(notification_id);
+            }
             self.note_notification_mutation();
             Some(unread)
         } else {

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -104,6 +104,12 @@ pub struct AppStateFile {
     pub snoozed_notifications: HashMap<String, SnoozeEntry>,
     #[serde(default)]
     pub dismissed_synthetic_ids: Vec<String>,
+    /// Per-thread local read timestamps, recorded when the user marks a
+    /// notification read in the app.  GitHub's `last_read_at` does not
+    /// advance for local reads, so this drives the "new since last read"
+    /// preview feed.
+    #[serde(default)]
+    pub read_cutoffs: HashMap<String, DateTime<Utc>>,
 }
 
 fn default_auto_mark_read() -> bool {
@@ -118,6 +124,7 @@ impl AppStateFile {
             pinned_notifications: Vec::new(),
             snoozed_notifications: HashMap::new(),
             dismissed_synthetic_ids: Vec::new(),
+            read_cutoffs: HashMap::new(),
         }
     }
 
@@ -249,6 +256,47 @@ impl AppStateFile {
         Ok(state.dismissed_synthetic_ids.into_iter().collect())
     }
 
+    /// Load local read cutoffs, dropping entries older than 30 days.
+    pub fn load_read_cutoffs() -> Result<HashMap<String, DateTime<Utc>>> {
+        let state = Self::load_full()?;
+        let horizon = Utc::now() - chrono::Duration::days(30);
+        Ok(state
+            .read_cutoffs
+            .into_iter()
+            .filter(|(_, ts)| *ts > horizon)
+            .collect())
+    }
+
+    /// Record a local read timestamp for a notification thread.
+    pub fn save_read_cutoff(thread_id: &str, cutoff: DateTime<Utc>) -> Result<()> {
+        Self::update_with(|state| {
+            state.read_cutoffs.insert(thread_id.to_string(), cutoff);
+            let horizon = Utc::now() - chrono::Duration::days(30);
+            state.read_cutoffs.retain(|_, ts| *ts > horizon);
+        })
+    }
+
+    /// Record the same local read timestamp for several notification threads.
+    pub fn save_read_cutoffs(thread_ids: &[String], cutoff: DateTime<Utc>) -> Result<()> {
+        if thread_ids.is_empty() {
+            return Ok(());
+        }
+        Self::update_with(|state| {
+            for thread_id in thread_ids {
+                state.read_cutoffs.insert(thread_id.clone(), cutoff);
+            }
+            let horizon = Utc::now() - chrono::Duration::days(30);
+            state.read_cutoffs.retain(|_, ts| *ts > horizon);
+        })
+    }
+
+    /// Remove a local read cutoff (e.g. when a mark-read is reverted).
+    pub fn remove_read_cutoff(thread_id: &str) -> Result<()> {
+        Self::update_with(|state| {
+            state.read_cutoffs.remove(thread_id);
+        })
+    }
+
     /// Keep only the most recent 200 entries, dropping the oldest.
     fn trim_dismissed(ids: &mut Vec<String>) {
         const MAX_DISMISSED: usize = 200;
@@ -308,7 +356,14 @@ pub fn load_context_cache() -> HashMap<String, String> {
 pub struct PersistedPreviewCacheEntry {
     pub data: PreviewData,
     pub updated_at: Option<DateTime<Utc>>,
+    /// Bumped whenever `PreviewData` gains fields that older entries lack;
+    /// entries with an older version are revalidated in the background.
+    #[serde(default)]
+    pub schema_version: u32,
 }
+
+/// Current preview-cache schema version.  Bump when `PreviewData` grows.
+pub const PREVIEW_CACHE_SCHEMA_VERSION: u32 = 1;
 
 /// Path of the preview cache file (sibling of the state file).
 fn get_preview_cache_path() -> Result<PathBuf> {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1214,7 +1214,7 @@ impl App {
                 } else if selected_was_invalidated {
                     // Preview pane is off but the selected entry was invalidated: clear the
                     // cached UI content so pressing Tab won't show stale data.
-                    self.state.preview_content = None;
+                    self.state.set_preview_content(None, None);
                 }
 
                 // Background-revalidate all remaining stale entries (low priority).
@@ -1337,7 +1337,7 @@ impl App {
             .map(|n| invalidated.contains(&n.preview_cache_key()))
             .unwrap_or(false)
         {
-            self.state.preview_content = None;
+            self.state.set_preview_content(None, None);
         }
 
         if let Some(ref pm) = self.preview_manager {
@@ -1374,40 +1374,41 @@ impl App {
         let notification = match self.state.selected_notification() {
             Some(n) => n.clone(),
             None => {
-                self.state.preview_content = None;
+                self.state.set_preview_content(None, None);
                 return;
             }
         };
 
         let Some(preview_manager) = self.preview_manager.as_ref() else {
-            self.state.preview_content = None;
+            self.state.set_preview_content(None, None);
             return;
         };
 
+        let cache_key = notification.preview_cache_key();
         match preview_manager.get_cached_status(&notification) {
             CacheStatus::Fresh(data) => {
-                self.state.preview_content = Some(data);
+                self.state.set_preview_content(Some(data), Some(cache_key));
                 self.state.preview_scroll = 0;
             }
             CacheStatus::Stale(data) => {
                 // Show the cached content immediately and revalidate in the background.
-                self.state.preview_content = Some(data);
-                self.state.preview_scroll = 0;
                 preview_manager.request_revalidation(&notification, PRIORITY_HIGH);
+                self.state.set_preview_content(Some(data), Some(cache_key));
+                self.state.preview_scroll = 0;
             }
             CacheStatus::Miss => {
+                let loading = PreviewData::Generic {
+                    title: "Loading details...".to_string(),
+                    body: "⏳ Fetching details...\n\nThis may take a moment.".to_string(),
+                };
                 if preview_manager.is_loading(&notification) {
-                    self.state.preview_content = Some(PreviewData::Generic {
-                        title: "Loading details...".to_string(),
-                        body: "⏳ Fetching details...\n\nThis may take a moment.".to_string(),
-                    });
+                    self.state
+                        .set_preview_content(Some(loading), Some(cache_key));
                     return;
                 }
                 preview_manager.request_preview(&notification, PRIORITY_HIGH);
-                self.state.preview_content = Some(PreviewData::Generic {
-                    title: "Loading details...".to_string(),
-                    body: "⏳ Fetching details...\n\nThis may take a moment.".to_string(),
-                });
+                self.state
+                    .set_preview_content(Some(loading), Some(cache_key));
                 self.state.preview_scroll = 0;
             }
         }
@@ -1626,7 +1627,8 @@ impl App {
                     if let Some(current_notif) = self.state.selected_notification() {
                         if current_notif.preview_cache_key() == completed_key {
                             if let Some(data) = preview_manager.get_cached_by_key(&completed_key) {
-                                self.state.preview_content = Some(data);
+                                self.state
+                                    .set_preview_content(Some(data), Some(completed_key));
                                 self.state.preview_scroll = 0;
                             }
                         }
@@ -2707,6 +2709,15 @@ impl App {
         };
         let notification_id = notification.id.clone();
         let repo = notification.repo_full_name().to_string();
+        let selected_key = notification.preview_cache_key();
+
+        // Only merge when the preview shown belongs to the selected
+        // notification; a stale preview must never drive a merge.
+        if self.state.preview_content_key.as_deref() != Some(selected_key.as_str()) {
+            self.state.status_message =
+                Some("Preview is out of date: reopen the preview before merging".to_string());
+            return;
+        }
 
         let Some(PreviewData::PullRequest {
             number,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -148,6 +148,27 @@ pub struct App {
     // local mutations from the main loop.
     last_seen_mutation_seq: u64,
     author_enrichment_rx: Option<Receiver<EnrichmentResult>>,
+    // In-flight quick-merge, one at a time (guards double-submission).
+    merge_rx: Option<Receiver<MergeOutcome>>,
+}
+
+/// Result of a background pull-request merge.
+struct MergeOutcome {
+    notification_id: String,
+    repo: String,
+    number: u64,
+    result: crate::error::Result<String>,
+}
+
+fn collect_successful_batch_result(
+    successful_ids: &mut Vec<String>,
+    notification_id: &str,
+    result: crate::error::Result<()>,
+) {
+    match result {
+        Ok(()) => successful_ids.push(notification_id.to_string()),
+        Err(e) => eprintln!("Failed to process notification {notification_id}: {e}"),
+    }
 }
 
 /// Results from the background enrichment thread that resolves author logins
@@ -208,6 +229,7 @@ impl App {
             refresh_generation: 0,
             last_seen_mutation_seq: 0,
             author_enrichment_rx: None,
+            merge_rx: None,
         }
     }
 
@@ -937,6 +959,7 @@ impl App {
 
                 // Take the client temporarily to avoid borrow conflicts during render
                 if let Some(client) = self.api_client.take() {
+                    let mut successful_ids = Vec::new();
                     for (i, notification_id) in to_process.iter().enumerate() {
                         // Update progress
                         self.state.loading_progress = Some((i + 1, total));
@@ -948,15 +971,21 @@ impl App {
                         }
 
                         // Make the API call
-                        match selected {
+                        let result = match selected {
                             MarkAllOption::MarkReadAndArchive => {
-                                let _ = client.mark_thread_done(notification_id);
+                                client.mark_thread_done(notification_id)
                             }
                             MarkAllOption::MarkReadOnly => {
-                                let _ = client.mark_notification_read(notification_id);
+                                client.mark_notification_read(notification_id)
                             }
-                        }
+                        };
+                        collect_successful_batch_result(
+                            &mut successful_ids,
+                            notification_id,
+                            result,
+                        );
                     }
+                    self.state.record_read_cutoffs(&successful_ids);
 
                     // Clear progress and restore client
                     self.state.loading_progress = None;
@@ -996,6 +1025,7 @@ impl App {
                 let total = notification_ids.len();
                 // Take the client temporarily to avoid borrow conflicts during render
                 if let Some(client) = self.api_client.take() {
+                    let mut successful_ids = Vec::new();
                     for (i, notification_id) in notification_ids.iter().enumerate() {
                         // Update progress
                         self.state.loading_progress = Some((i + 1, total));
@@ -1016,10 +1046,13 @@ impl App {
                             }
                         };
 
-                        if let Err(e) = result {
-                            eprintln!("Failed to process notification {}: {}", notification_id, e);
-                        }
+                        collect_successful_batch_result(
+                            &mut successful_ids,
+                            notification_id,
+                            result,
+                        );
                     }
+                    self.state.record_read_cutoffs(&successful_ids);
 
                     // Clear progress and restore client
                     self.state.loading_progress = None;
@@ -1443,15 +1476,13 @@ impl App {
                 match rx.try_recv() {
                     Ok(result) => {
                         self.initial_load_rx = None;
-                        match result {
-                            Ok(data) => {
-                                self.apply_initial_load(data);
-                                // Persist the fresh fetch (post dismissed-filtering)
-                                // on the UI thread; workers never write the cache.
-                                self.persist_notifications_to_cache();
-                                self.last_seen_mutation_seq = self.state.notification_mutation_seq;
-                            }
-                            Err(e) => return Err(e),
+                        {
+                            let data = result?;
+                            self.apply_initial_load(data);
+                            // Persist the fresh fetch (post dismissed-filtering)
+                            // on the UI thread; workers never write the cache.
+                            self.persist_notifications_to_cache();
+                            self.last_seen_mutation_seq = self.state.notification_mutation_seq;
                         }
                     }
                     Err(TryRecvError::Disconnected) => {
@@ -1503,6 +1534,9 @@ impl App {
             // Persist local mutations (mark read, remove, ...) to the cache and
             // invalidate in-flight refresh snapshots that predate them.
             self.process_local_mutations();
+
+            // Apply any completed quick-merge.
+            self.process_merge_outcome();
 
             // Poll background refresh (after cache-hit startup)
             if let Some((generation, ref rx)) = self.background_refresh_rx {
@@ -1832,6 +1866,7 @@ impl App {
             if let Some(ref action) = self.state.confirm_action {
                 let count = match action {
                     ConfirmAction::ArchiveSelected { count, .. } => *count,
+                    ConfirmAction::MergePullRequest { .. } => 1,
                     ConfirmAction::MarkAllRead { .. } => self
                         .state
                         .filtered_notifications
@@ -1925,7 +1960,7 @@ impl App {
                 Some(ConfirmAction::ArchiveSelected { ref mut option, .. }) => {
                     *option = MarkAllOption::MarkReadAndArchive;
                 }
-                None => {}
+                Some(ConfirmAction::MergePullRequest { .. }) | None => {}
             },
             KeyCode::Down | KeyCode::Char('j') => match &mut self.state.confirm_action {
                 Some(ConfirmAction::MarkAllRead { ref mut selected }) => {
@@ -1934,7 +1969,7 @@ impl App {
                 Some(ConfirmAction::ArchiveSelected { ref mut option, .. }) => {
                     *option = MarkAllOption::MarkReadOnly;
                 }
-                None => {}
+                Some(ConfirmAction::MergePullRequest { .. }) | None => {}
             },
             KeyCode::Enter => {
                 if let Some(action) = self.state.confirm_action.take() {
@@ -2649,8 +2684,176 @@ impl App {
                     msg,
                 );
             }
+            ConfirmAction::MergePullRequest {
+                notification_id,
+                repo,
+                number,
+                title: _,
+                method,
+                head_sha,
+            } => {
+                self.spawn_merge(notification_id, repo, number, method, head_sha);
+            }
         }
         Ok(())
+    }
+
+    /// Open the merge confirmation dialog for the selected PR notification,
+    /// provided the preview data supports a safe merge.
+    fn request_merge_confirmation(&mut self) {
+        let Some(notification) = self.state.selected_notification() else {
+            self.state.status_message = Some("No notification selected".to_string());
+            return;
+        };
+        let notification_id = notification.id.clone();
+        let repo = notification.repo_full_name().to_string();
+
+        let Some(PreviewData::PullRequest {
+            number,
+            title,
+            state: pr_state,
+            is_draft,
+            head_ref_oid,
+            ..
+        }) = self.state.preview_content.as_ref()
+        else {
+            self.state.status_message =
+                Some("Merge is only available on pull request previews".to_string());
+            return;
+        };
+
+        if pr_state != "open" {
+            self.state.status_message = Some(format!("Pull request is {pr_state}"));
+            return;
+        }
+        if *is_draft {
+            self.state.status_message = Some("Draft pull requests cannot be merged".to_string());
+            return;
+        }
+        if head_ref_oid.is_empty() {
+            // Baseline GHES data lacks the head SHA: refuse rather than
+            // merging an unverified head.
+            self.state.status_message =
+                Some("Merge unavailable: head commit unknown (refresh the preview)".to_string());
+            return;
+        }
+        let Ok(number) = number.parse::<u64>() else {
+            self.state.status_message = Some("Invalid pull request number".to_string());
+            return;
+        };
+        if self.merge_rx.is_some() {
+            self.state.status_message = Some("A merge is already in progress".to_string());
+            return;
+        }
+
+        self.state.confirm_action = Some(ConfirmAction::MergePullRequest {
+            notification_id,
+            repo,
+            number,
+            title: title.clone(),
+            method: self.config.merge_method,
+            head_sha: head_ref_oid.clone(),
+        });
+        self.state.input_mode = InputMode::Confirm;
+    }
+
+    /// Run the merge on a background thread; the result is polled from the
+    /// main loop.  Only one merge may be in flight at a time.
+    fn spawn_merge(
+        &mut self,
+        notification_id: String,
+        repo: String,
+        number: u64,
+        method: crate::config::MergeMethod,
+        head_sha: String,
+    ) {
+        if self.merge_rx.is_some() {
+            self.state.status_message = Some("A merge is already in progress".to_string());
+            return;
+        }
+        let Some(ref client) = self.api_client else {
+            self.state.status_message = Some("No API client available".to_string());
+            return;
+        };
+        let Some((owner, repo_name)) = repo
+            .split_once('/')
+            .map(|(o, r)| (o.to_string(), r.to_string()))
+        else {
+            self.state.status_message = Some(format!("Invalid repository: {repo}"));
+            return;
+        };
+
+        let client = client.clone();
+        let (tx, rx) = mpsc::channel();
+        self.merge_rx = Some(rx);
+        self.state.status_message = Some(format!("Merging {repo}#{number}…"));
+
+        std::thread::spawn(move || {
+            let result = client.merge_pull_request(
+                &owner,
+                &repo_name,
+                number,
+                method.api_value(),
+                &head_sha,
+            );
+            let _ = tx.send(MergeOutcome {
+                notification_id,
+                repo,
+                number,
+                result,
+            });
+        });
+    }
+
+    /// Apply a completed merge: status message, mark read, refresh preview.
+    fn process_merge_outcome(&mut self) {
+        let Some(ref rx) = self.merge_rx else {
+            return;
+        };
+        let outcome = match rx.try_recv() {
+            Ok(outcome) => outcome,
+            Err(TryRecvError::Empty) => return,
+            Err(TryRecvError::Disconnected) => {
+                self.merge_rx = None;
+                self.state.status_message = Some("Merge thread ended unexpectedly".to_string());
+                return;
+            }
+        };
+        self.merge_rx = None;
+
+        match outcome.result {
+            Ok(message) => {
+                self.state.status_message = Some(if message.is_empty() {
+                    format!("Merged {}#{}", outcome.repo, outcome.number)
+                } else {
+                    format!("Merged {}#{}: {}", outcome.repo, outcome.number, message)
+                });
+                // Mark read locally (records the read cutoff, clearing the
+                // new-activity feed) and persist on GitHub's side.
+                self.state.mark_notification_read(&outcome.notification_id);
+                if let Some(ref client) = self.api_client {
+                    let _ = client.mark_notification_read(&outcome.notification_id);
+                }
+                // Revalidate the preview so the merged state shows up.
+                let notification = self
+                    .state
+                    .notifications
+                    .iter()
+                    .find(|n| n.id == outcome.notification_id)
+                    .cloned();
+                if let (Some(pm), Some(notification)) =
+                    (self.preview_manager.as_ref(), notification)
+                {
+                    pm.request_revalidation(&notification, crate::preview_manager::PRIORITY_HIGH);
+                }
+            }
+            Err(e) => {
+                self.state.status_message = Some(format!(
+                    "Merge of {}#{} failed: {}",
+                    outcome.repo, outcome.number, e
+                ));
+            }
+        }
     }
 
     fn handle_normal_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -3273,6 +3476,12 @@ impl App {
                 let _ = crate::state_file::AppStateFile::save_auto_mark_read(
                     self.auto_mark_read_enabled,
                 );
+            }
+            KeyCode::Char('m') => {
+                self.request_merge_confirmation();
+            }
+            KeyCode::Char('c') => {
+                self.preview_widget.toggle_ci_checks(&self.state);
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 // Scroll preview up
@@ -3967,6 +4176,20 @@ mod tests {
         // Local state should be updated (no API client, so no API call)
         assert!(!app.state.notifications[0].is_unread());
         assert!(app.pending_mark_read.is_none());
+    }
+
+    #[test]
+    fn batch_cutoffs_exclude_failed_operations() {
+        let mut successful_ids = Vec::new();
+
+        collect_successful_batch_result(&mut successful_ids, "ok", Ok(()));
+        collect_successful_batch_result(
+            &mut successful_ids,
+            "failed",
+            Err(crate::error::Error::Config("request failed".to_string())),
+        );
+
+        assert_eq!(successful_ids, ["ok"]);
     }
 
     #[test]

--- a/src/ui/components/confirm.rs
+++ b/src/ui/components/confirm.rs
@@ -28,7 +28,84 @@ impl ConfirmWidget {
                     format!(" Mark {} Notifications ", count)
                 }
             }
+            ConfirmAction::MergePullRequest { number, .. } => {
+                format!(" Merge Pull Request #{} ", number)
+            }
         }
+    }
+
+    /// Dedicated Enter/Esc-only dialog for merging a pull request.
+    fn render_merge(
+        &self,
+        frame: &mut Frame,
+        centered_area: Rect,
+        repo: &str,
+        number: u64,
+        title: &str,
+        method: crate::config::MergeMethod,
+    ) {
+        let colors = &self.colors;
+        let max_title = centered_area.width.saturating_sub(6) as usize;
+        let mut display_title = title.to_string();
+        if display_title.chars().count() > max_title {
+            display_title = display_title
+                .chars()
+                .take(max_title.saturating_sub(1))
+                .collect();
+            display_title.push('…');
+        }
+
+        let content = vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    display_title,
+                    Style::default().fg(colors.fg).add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{repo}#{number}"), Style::default().fg(colors.cyan)),
+                Span::styled(" · method: ", Style::default().fg(colors.fg_dim)),
+                Span::styled(
+                    method.api_value(),
+                    Style::default()
+                        .fg(colors.magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled("Enter", Style::default().fg(colors.green)),
+                Span::raw(" merge  "),
+                Span::styled("Esc", Style::default().fg(colors.red)),
+                Span::raw(" cancel"),
+            ]),
+        ];
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(vec![
+                Span::styled(" ", Style::default()),
+                Span::styled(
+                    format!(" Merge Pull Request #{} ", number),
+                    Style::default()
+                        .fg(colors.green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" ", Style::default()),
+            ])
+            .title_alignment(Alignment::Center)
+            .border_style(Style::default().fg(colors.green))
+            .border_type(ratatui::widgets::BorderType::Rounded);
+
+        let paragraph = Paragraph::new(content)
+            .block(block)
+            .alignment(Alignment::Left);
+
+        frame.render_widget(paragraph, centered_area);
     }
 
     pub fn render(
@@ -55,9 +132,22 @@ impl ConfirmWidget {
 
         frame.render_widget(Clear, centered_area);
 
+        if let ConfirmAction::MergePullRequest {
+            repo,
+            number,
+            title,
+            method,
+            ..
+        } = action
+        {
+            self.render_merge(frame, centered_area, repo, *number, title, *method);
+            return;
+        }
+
         let selected = match action {
             ConfirmAction::MarkAllRead { selected } => *selected,
             ConfirmAction::ArchiveSelected { option, .. } => *option,
+            ConfirmAction::MergePullRequest { .. } => unreachable!(),
         };
 
         let (archive_indicator, read_indicator) = match selected {

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -140,6 +140,14 @@ impl HelpWidget {
                         desc: "Archive (done) notification(s)",
                     },
                     HelpLine {
+                        key: "m",
+                        desc: "Merge pull request (with confirmation)",
+                    },
+                    HelpLine {
+                        key: "c",
+                        desc: "Expand/collapse pull request CI checks",
+                    },
+                    HelpLine {
                         key: "!",
                         desc: "Pin/unpin notification",
                     },

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -6,6 +6,7 @@ pub mod help;
 pub mod help_search;
 pub mod list;
 pub mod loading;
+pub mod pills;
 pub mod preview;
 pub mod session_picker;
 pub mod status;

--- a/src/ui/components/pills.rs
+++ b/src/ui/components/pills.rs
@@ -1,0 +1,188 @@
+//! Pill/chip rendering helpers for the pull-request preview.
+//!
+//! Pills are padded, background-coloured spans in the style of
+//! lazyworktree's CI chips: ` ✓ Passed ` with a contrasting foreground.
+
+use crate::ui::theme::ColorPalette;
+use ratatui::prelude::*;
+
+/// Visual tone of a pill, mapped to palette colours at render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PillTone {
+    Success,
+    Failure,
+    Pending,
+    Running,
+    Neutral,
+    Merged,
+    Info,
+}
+
+impl PillTone {
+    fn colors(self, palette: &ColorPalette) -> (Color, Color) {
+        // (bg, fg): coloured background with the dark base as text colour
+        // keeps pills readable on both light and dark palettes.
+        match self {
+            PillTone::Success => (palette.green, palette.bg),
+            PillTone::Failure => (palette.red, palette.bg),
+            PillTone::Pending => (palette.yellow, palette.bg),
+            PillTone::Running => (palette.blue, palette.bg),
+            PillTone::Neutral => (palette.bg_highlight, palette.fg_muted),
+            PillTone::Merged => (palette.magenta, palette.bg),
+            PillTone::Info => (palette.cyan, palette.bg),
+        }
+    }
+
+    /// Icon used inside pills and for per-check lines.
+    pub fn icon(self) -> &'static str {
+        match self {
+            PillTone::Success => "✓",
+            PillTone::Failure => "✗",
+            PillTone::Pending => "●",
+            PillTone::Running => "◐",
+            PillTone::Neutral => "○",
+            PillTone::Merged => "⇌",
+            PillTone::Info => "◆",
+        }
+    }
+
+    /// Foreground colour for non-pill (plain icon) rendering.
+    pub fn fg(self, palette: &ColorPalette) -> Color {
+        match self {
+            PillTone::Success => palette.green,
+            PillTone::Failure => palette.red,
+            PillTone::Pending => palette.yellow,
+            PillTone::Running => palette.blue,
+            PillTone::Neutral => palette.fg_dim,
+            PillTone::Merged => palette.magenta,
+            PillTone::Info => palette.cyan,
+        }
+    }
+}
+
+/// A padded, coloured chip span: ` ✓ label `.
+pub fn pill(label: &str, tone: PillTone, palette: &ColorPalette) -> Span<'static> {
+    let (bg, fg) = tone.colors(palette);
+    Span::styled(
+        format!(" {} {} ", tone.icon(), label),
+        Style::default().bg(bg).fg(fg).add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Map a normalised CI check state (uppercase) to a pill tone.
+pub fn ci_state_tone(state: &str) -> PillTone {
+    match state {
+        "SUCCESS" | "COMPLETED" => PillTone::Success,
+        "FAILURE" | "ERROR" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE" => {
+            PillTone::Failure
+        }
+        "PENDING" | "QUEUED" | "WAITING" | "REQUESTED" | "EXPECTED" => PillTone::Pending,
+        "IN_PROGRESS" => PillTone::Running,
+        _ => PillTone::Neutral, // CANCELLED, SKIPPED, NEUTRAL, STALE, unknown
+    }
+}
+
+/// Human label for a normalised CI check state.
+pub fn ci_state_label(state: &str) -> String {
+    match state {
+        "SUCCESS" => "Passed".to_string(),
+        "FAILURE" => "Failed".to_string(),
+        "ERROR" => "Error".to_string(),
+        "PENDING" | "QUEUED" | "WAITING" | "REQUESTED" | "EXPECTED" => "Pending".to_string(),
+        "IN_PROGRESS" => "Running".to_string(),
+        "CANCELLED" => "Cancelled".to_string(),
+        "TIMED_OUT" => "Timed out".to_string(),
+        "ACTION_REQUIRED" => "Action required".to_string(),
+        "SKIPPED" => "Skipped".to_string(),
+        "NEUTRAL" => "Neutral".to_string(),
+        "STALE" => "Stale".to_string(),
+        other => {
+            let lower = other.to_lowercase().replace('_', " ");
+            let mut chars = lower.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        }
+    }
+}
+
+/// Fallback aggregate when the server rollup state is absent.
+/// Priority: failure > pending/running > success > neutral.
+pub fn aggregate_ci_state(checks: &[crate::preview::CiCheck]) -> String {
+    let mut has_pending = false;
+    let mut has_success = false;
+    for check in checks {
+        match ci_state_tone(&check.state) {
+            PillTone::Failure => return "FAILURE".to_string(),
+            PillTone::Pending | PillTone::Running => has_pending = true,
+            PillTone::Success => has_success = true,
+            _ => {}
+        }
+    }
+    if has_pending {
+        "PENDING".to_string()
+    } else if has_success {
+        "SUCCESS".to_string()
+    } else {
+        "NEUTRAL".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preview::CiCheck;
+
+    fn check(state: &str) -> CiCheck {
+        CiCheck {
+            name: "c".to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    #[test]
+    fn ci_state_tones_cover_known_states() {
+        assert_eq!(ci_state_tone("SUCCESS"), PillTone::Success);
+        assert_eq!(ci_state_tone("FAILURE"), PillTone::Failure);
+        assert_eq!(ci_state_tone("ERROR"), PillTone::Failure);
+        assert_eq!(ci_state_tone("TIMED_OUT"), PillTone::Failure);
+        assert_eq!(ci_state_tone("PENDING"), PillTone::Pending);
+        assert_eq!(ci_state_tone("QUEUED"), PillTone::Pending);
+        assert_eq!(ci_state_tone("IN_PROGRESS"), PillTone::Running);
+        assert_eq!(ci_state_tone("SKIPPED"), PillTone::Neutral);
+        assert_eq!(ci_state_tone("SOMETHING_NEW"), PillTone::Neutral);
+    }
+
+    #[test]
+    fn aggregate_prefers_failure_then_pending() {
+        assert_eq!(
+            aggregate_ci_state(&[check("SUCCESS"), check("FAILURE"), check("PENDING")]),
+            "FAILURE"
+        );
+        assert_eq!(
+            aggregate_ci_state(&[check("SUCCESS"), check("IN_PROGRESS")]),
+            "PENDING"
+        );
+        assert_eq!(
+            aggregate_ci_state(&[check("SUCCESS"), check("SKIPPED")]),
+            "SUCCESS"
+        );
+        assert_eq!(aggregate_ci_state(&[check("SKIPPED")]), "NEUTRAL");
+        assert_eq!(aggregate_ci_state(&[]), "NEUTRAL");
+    }
+
+    #[test]
+    fn labels_are_humanised() {
+        assert_eq!(ci_state_label("SUCCESS"), "Passed");
+        assert_eq!(ci_state_label("ACTION_REQUIRED"), "Action required");
+        assert_eq!(ci_state_label("SOME_NEW_STATE"), "Some new state");
+    }
+
+    #[test]
+    fn pill_contains_icon_and_label() {
+        let palette = ColorPalette::from_name("tokyo_night");
+        let span = pill("Passed", PillTone::Success, &palette);
+        assert_eq!(span.content.as_ref(), " ✓ Passed ");
+    }
+}

--- a/src/ui/components/preview.rs
+++ b/src/ui/components/preview.rs
@@ -1,6 +1,11 @@
 use crate::markdown::MarkdownRenderer;
-use crate::preview::{PreviewData, PreviewHeaderKind, PreviewView};
+use crate::preview::{
+    LatestComment, PreviewData, PreviewHeaderKind, PreviewView, TimelineEntry, TimelineKind,
+};
 use crate::state::AppState;
+use crate::ui::components::pills::{
+    aggregate_ci_state, ci_state_label, ci_state_tone, pill, PillTone,
+};
 use crate::ui::theme::{ColorPalette, Theme};
 use ratatui::{
     prelude::*,
@@ -16,6 +21,7 @@ pub struct PreviewWidget {
     scrollbar_state: ScrollbarState,
     cached_lines: Vec<Line<'static>>,
     cached_signature: Option<String>,
+    expanded_ci_key: Option<String>,
 }
 
 impl PreviewWidget {
@@ -26,7 +32,28 @@ impl PreviewWidget {
             scrollbar_state: ScrollbarState::default(),
             cached_lines: Vec::new(),
             cached_signature: None,
+            expanded_ci_key: None,
         }
+    }
+
+    pub fn toggle_ci_checks(&mut self, state: &AppState) {
+        let has_checks = matches!(
+            state.preview_content,
+            Some(PreviewData::PullRequest { ref ci_checks, .. }) if !ci_checks.is_empty()
+        );
+        let Some(key) = has_checks
+            .then(|| state.selected_notification().map(|n| n.preview_cache_key()))
+            .flatten()
+        else {
+            return;
+        };
+
+        if self.expanded_ci_key.as_deref() == Some(&key) {
+            self.expanded_ci_key = None;
+        } else {
+            self.expanded_ci_key = Some(key);
+        }
+        self.cached_signature = None;
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, state: &AppState) {
@@ -201,58 +228,77 @@ impl PreviewWidget {
         preview_data: &PreviewData,
         state: &AppState,
     ) {
-        let preview_view = PreviewView::from(preview_data);
+        let is_pull_request = matches!(preview_data, PreviewData::PullRequest { .. });
 
-        let header_lines = self.get_header_lines(&preview_view);
-        let separator_line = self.get_separator_line(area.width);
+        if is_pull_request {
+            let selected_key = state
+                .selected_notification()
+                .map(|notification| notification.preview_cache_key());
+            let ci_expanded = selected_key.as_ref() == self.expanded_ci_key.as_ref();
+            let cutoff = state
+                .selected_notification()
+                .and_then(|n| state.effective_read_cutoff(n));
+            let signature = format!(
+                "pr|{:?}|{:?}|{}|{}",
+                preview_data, cutoff, area.width, ci_expanded
+            );
+            if self.cached_signature.as_ref() != Some(&signature) {
+                self.cached_lines = self.build_pr_lines(preview_data, cutoff, ci_expanded);
+                self.cached_signature = Some(signature);
+            }
+        } else {
+            let preview_view = PreviewView::from(preview_data);
+            let header_lines = self.get_header_lines(&preview_view);
+            let separator_line = self.get_separator_line(area.width);
 
-        let body = preview_view.body.as_str();
-        let header_signature = preview_view
-            .header
-            .iter()
-            .map(|line| line.text())
-            .collect::<Vec<_>>()
-            .join("\n");
-        let signature = format!("{header_signature}\n{body}");
+            let body = preview_view.body.as_str();
+            let header_signature = preview_view
+                .header
+                .iter()
+                .map(|line| line.text())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let signature = format!("{header_signature}\n{body}");
 
-        if self.cached_signature.as_ref() != Some(&signature) {
-            let body_lines = MarkdownRenderer::render_simple(body, &self.colors);
+            if self.cached_signature.as_ref() != Some(&signature) {
+                let body_lines = MarkdownRenderer::render_simple(body, &self.colors);
 
-            let mut all_lines = Vec::new();
-            all_lines.extend(header_lines);
-            all_lines.push(separator_line);
-            all_lines.extend(body_lines);
+                let mut all_lines = Vec::new();
+                all_lines.extend(header_lines);
+                all_lines.push(separator_line);
+                all_lines.extend(body_lines);
 
-            self.cached_signature = Some(signature);
-            self.cached_lines = all_lines;
+                self.cached_signature = Some(signature);
+                self.cached_lines = all_lines;
+            }
         }
 
-        let content_height = self.cached_lines.len();
         let visible_height = area.height as usize;
-
-        self.scrollbar_state = self
-            .scrollbar_state
-            .content_length(content_height)
-            .viewport_content_length(visible_height)
-            .position(state.preview_scroll);
-
-        let start = state
-            .preview_scroll
-            .min(self.cached_lines.len().saturating_sub(1));
-        let end = (start + visible_height).min(self.cached_lines.len());
-        let visible_lines: Vec<Line> = if self.cached_lines.is_empty() {
+        let lines: Vec<Line> = if self.cached_lines.is_empty() {
             vec![Line::from(vec![Span::styled(
                 "No description",
                 Style::default().fg(self.colors.fg_dim),
             )])]
         } else {
-            self.cached_lines[start..end].to_vec()
+            self.cached_lines.clone()
         };
 
-        let paragraph = Paragraph::new(visible_lines)
+        let paragraph = Paragraph::new(lines)
             .style(self.theme.preview)
-            .wrap(ratatui::widgets::Wrap { trim: true });
+            .wrap(ratatui::widgets::Wrap { trim: false });
 
+        // Wrapped visual rows, so long comment lines scroll correctly.
+        let content_height = paragraph.line_count(area.width);
+        let max_scroll = content_height.saturating_sub(visible_height);
+        let offset = state.preview_scroll.min(max_scroll);
+
+        self.scrollbar_state = self
+            .scrollbar_state
+            .content_length(content_height)
+            .viewport_content_length(visible_height)
+            .position(offset);
+
+        let paragraph = paragraph.scroll((offset.min(u16::MAX as usize) as u16, 0));
         frame.render_widget(paragraph, area);
 
         if content_height > visible_height {
@@ -265,5 +311,461 @@ impl PreviewWidget {
 
             frame.render_stateful_widget(scrollbar, area, &mut self.scrollbar_state);
         }
+    }
+
+    fn section_heading(&self, text: &str, extra: Vec<Span<'static>>) -> Line<'static> {
+        let mut spans = vec![
+            Span::styled(
+                "▌ ",
+                Style::default()
+                    .fg(self.colors.blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                text.to_string(),
+                Style::default()
+                    .fg(self.colors.fg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ];
+        if !extra.is_empty() {
+            spans.push(Span::raw("  "));
+            spans.extend(extra);
+        }
+        Line::from(spans)
+    }
+
+    /// Build the redesigned pull-request preview: readiness pills, the
+    /// new-activity feed, then CI checks.
+    fn build_pr_lines(
+        &self,
+        preview_data: &PreviewData,
+        read_cutoff: Option<chrono::DateTime<chrono::Utc>>,
+        ci_expanded: bool,
+    ) -> Vec<Line<'static>> {
+        let PreviewData::PullRequest {
+            number,
+            title,
+            state: pr_state,
+            author,
+            mergeable,
+            labels,
+            review_decision,
+            is_draft,
+            ci_status,
+            additions,
+            deletions,
+            changed_files,
+            latest_comment,
+            ci_checks,
+            ci_total_count,
+            merge_state_status,
+            head_ref_oid,
+            base_ref,
+            head_ref,
+            timeline,
+            timeline_total_count,
+            ..
+        } = preview_data
+        else {
+            return Vec::new();
+        };
+
+        let colors = &self.colors;
+        let mut lines: Vec<Line<'static>> = Vec::new();
+
+        // ── Title ────────────────────────────────────────────────────────
+        let state_text = if *is_draft && pr_state == "open" {
+            "draft"
+        } else {
+            pr_state.as_str()
+        };
+        let state_tone = match state_text {
+            "open" => PillTone::Success,
+            "merged" => PillTone::Merged,
+            "closed" => PillTone::Failure,
+            _ => PillTone::Neutral,
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("PR #{number} "),
+                Style::default()
+                    .fg(colors.blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                title.clone(),
+                Style::default().fg(colors.fg).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            pill(state_text, state_tone, colors),
+        ]));
+
+        // ── Meta line: author · branches · diffstat ─────────────────────
+        let mut meta = vec![Span::styled(
+            format!("@{author}"),
+            Style::default().fg(colors.cyan),
+        )];
+        if !base_ref.is_empty() && !head_ref.is_empty() {
+            meta.push(Span::styled(" · ", Style::default().fg(colors.fg_dim)));
+            meta.push(Span::styled(
+                format!("{base_ref} ← {head_ref}"),
+                Style::default().fg(colors.fg_muted),
+            ));
+        }
+        meta.push(Span::styled(" · ", Style::default().fg(colors.fg_dim)));
+        meta.push(Span::styled(
+            format!("+{additions}"),
+            Style::default().fg(colors.green),
+        ));
+        meta.push(Span::raw(" "));
+        meta.push(Span::styled(
+            format!("−{deletions}"),
+            Style::default().fg(colors.red),
+        ));
+        meta.push(Span::styled(
+            format!(" · {changed_files} files"),
+            Style::default().fg(colors.fg_muted),
+        ));
+        lines.push(Line::from(meta));
+
+        if !labels.is_empty() {
+            lines.push(Line::from(vec![Span::styled(
+                labels
+                    .iter()
+                    .map(|l| format!("({l})"))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                Style::default()
+                    .fg(colors.cyan)
+                    .add_modifier(Modifier::ITALIC),
+            )]));
+        }
+        lines.push(Line::from(""));
+
+        // ── Merge readiness pills ────────────────────────────────────────
+        let mut pills_row: Vec<Span<'static>> = Vec::new();
+        let mergeable_tone = match mergeable.as_str() {
+            "Yes" => PillTone::Success,
+            "No" => PillTone::Failure,
+            _ => PillTone::Neutral,
+        };
+        pills_row.push(pill(
+            match mergeable.as_str() {
+                "Yes" => "Mergeable",
+                "No" => "Conflicts",
+                _ => "Mergeable?",
+            },
+            mergeable_tone,
+            colors,
+        ));
+        pills_row.push(Span::raw(" "));
+
+        let (review_label, review_tone) = match review_decision.as_str() {
+            "APPROVED" => ("Approved", PillTone::Success),
+            "CHANGES_REQUESTED" => ("Changes requested", PillTone::Failure),
+            "REVIEW_REQUIRED" => ("Review required", PillTone::Pending),
+            _ => ("No review", PillTone::Neutral),
+        };
+        pills_row.push(pill(review_label, review_tone, colors));
+        pills_row.push(Span::raw(" "));
+
+        let effective_ci = if ci_status == "UNKNOWN" && !ci_checks.is_empty() {
+            aggregate_ci_state(ci_checks)
+        } else {
+            ci_status.clone()
+        };
+        if effective_ci != "UNKNOWN" {
+            pills_row.push(pill(
+                &format!("CI {}", ci_state_label(&effective_ci)),
+                ci_state_tone(&effective_ci),
+                colors,
+            ));
+            pills_row.push(Span::raw(" "));
+        }
+
+        if !merge_state_status.is_empty() {
+            let (ms_label, ms_tone) = match merge_state_status.as_str() {
+                "CLEAN" => ("Ready to merge", PillTone::Success),
+                "BLOCKED" => ("Blocked", PillTone::Failure),
+                "BEHIND" => ("Behind base", PillTone::Pending),
+                "DIRTY" => ("Conflicts", PillTone::Failure),
+                "UNSTABLE" => ("Unstable", PillTone::Pending),
+                "DRAFT" => ("Draft", PillTone::Neutral),
+                "HAS_HOOKS" => ("Has hooks", PillTone::Info),
+                other => (other, PillTone::Neutral),
+            };
+            pills_row.push(pill(ms_label, ms_tone, colors));
+        }
+        lines.push(Line::from(pills_row));
+
+        let merge_ready = pr_state == "open" && !*is_draft && !head_ref_oid.is_empty();
+        if merge_ready {
+            lines.push(Line::from(vec![Span::styled(
+                "  press m to merge",
+                Style::default()
+                    .fg(colors.fg_dim)
+                    .add_modifier(Modifier::ITALIC),
+            )]));
+        }
+        lines.push(Line::from(""));
+
+        // ── New activity since last read ─────────────────────────────────
+        let activity = merge_pr_activity(timeline, latest_comment.as_ref());
+        let new_entries: Vec<&TimelineEntry> = match read_cutoff {
+            Some(cutoff) => activity
+                .iter()
+                .filter(|entry| activity_is_new(entry, cutoff))
+                .collect(),
+            // Never read: avoid dumping the whole thread.
+            None => activity.iter().rev().take(1).rev().collect(),
+        };
+
+        if !new_entries.is_empty() {
+            lines.push(self.section_heading(
+                &format!("New since last read ({})", new_entries.len()),
+                Vec::new(),
+            ));
+            let shown_earliest = activity
+                .iter()
+                .position(|e| std::ptr::eq(e, *new_entries.first().unwrap()))
+                .unwrap_or(0);
+            if *timeline_total_count > timeline.len() as u64 && shown_earliest == 0 {
+                lines.push(Line::from(vec![Span::styled(
+                    "  … earlier activity not shown",
+                    Style::default().fg(colors.fg_dim),
+                )]));
+            }
+            for entry in &new_entries {
+                lines.push(Line::from(""));
+                lines.extend(self.timeline_entry_lines(entry));
+            }
+            lines.push(Line::from(""));
+        }
+
+        // ── CI checks ────────────────────────────────────────────────────
+        if !ci_checks.is_empty() {
+            let mut counts = [0_u64; 5];
+            for check in ci_checks {
+                let index = match ci_state_tone(&check.state) {
+                    PillTone::Success => 0,
+                    PillTone::Failure => 1,
+                    PillTone::Running => 2,
+                    PillTone::Pending => 3,
+                    _ => 4,
+                };
+                counts[index] += 1;
+            }
+
+            let mut summary = Vec::new();
+            for (count, label, tone) in [
+                (counts[0], "passed", PillTone::Success),
+                (counts[1], "failed", PillTone::Failure),
+                (counts[2], "running", PillTone::Running),
+                (counts[3], "pending", PillTone::Pending),
+                (counts[4], "other", PillTone::Neutral),
+            ] {
+                if count > 0 {
+                    summary.push(pill(&format!("{count} {label}"), tone, colors));
+                    summary.push(Span::raw(" "));
+                }
+            }
+
+            lines.push(self.section_heading(
+                if ci_expanded {
+                    "CI Checks ▾"
+                } else {
+                    "CI Checks ▸"
+                },
+                summary,
+            ));
+            lines.push(Line::from(Span::styled(
+                if ci_expanded {
+                    "  c collapse checks"
+                } else {
+                    "  c expand checks"
+                },
+                Style::default()
+                    .fg(colors.fg_dim)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+
+            if ci_expanded {
+                for check in ci_checks {
+                    let tone = ci_state_tone(&check.state);
+                    lines.push(Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(
+                            tone.icon().to_string(),
+                            Style::default()
+                                .fg(tone.fg(colors))
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw(" "),
+                        Span::styled(check.name.clone(), Style::default().fg(colors.fg)),
+                    ]));
+                }
+            }
+            if ci_expanded && *ci_total_count > ci_checks.len() as u64 {
+                lines.push(Line::from(vec![Span::styled(
+                    format!(
+                        "  … {} more checks not shown",
+                        ci_total_count - ci_checks.len() as u64
+                    ),
+                    Style::default().fg(colors.fg_dim),
+                )]));
+            }
+        }
+
+        lines
+    }
+
+    /// Attribution line plus markdown-rendered body for one timeline entry.
+    fn timeline_entry_lines(&self, entry: &TimelineEntry) -> Vec<Line<'static>> {
+        let colors = &self.colors;
+        let (verb, tone, icon) = match entry.kind {
+            TimelineKind::Comment => ("commented", PillTone::Info, "💬"),
+            TimelineKind::Approved => ("approved", PillTone::Success, "✅"),
+            TimelineKind::ChangesRequested => ("requested changes", PillTone::Failure, "✋"),
+            TimelineKind::Commented => ("reviewed", PillTone::Info, "👀"),
+            TimelineKind::Dismissed => ("dismissed a review", PillTone::Neutral, "🚫"),
+        };
+        let mut lines = vec![Line::from(vec![
+            Span::raw(format!("{icon} ")),
+            Span::styled(
+                format!("@{}", entry.author),
+                Style::default()
+                    .fg(colors.cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                verb.to_string(),
+                Style::default()
+                    .fg(tone.fg(colors))
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(" · {}", format_timestamp(&entry.timestamp)),
+                Style::default().fg(colors.fg_dim),
+            ),
+        ])];
+        if !entry.body.is_empty() {
+            lines.extend(MarkdownRenderer::render_simple(&entry.body, colors));
+        }
+        lines
+    }
+}
+
+/// Add the notification's triggering comment to the GraphQL activity feed.
+/// The REST URL can identify activity that is absent from the selected
+/// GraphQL timeline item types, so merge and deduplicate before filtering.
+fn merge_pr_activity(
+    timeline: &[TimelineEntry],
+    latest_comment: Option<&LatestComment>,
+) -> Vec<TimelineEntry> {
+    let mut activity = timeline.to_vec();
+    if let Some(comment) = latest_comment {
+        let entry = TimelineEntry {
+            author: comment.author.clone(),
+            kind: TimelineKind::Comment,
+            body: comment.body.clone(),
+            timestamp: comment.created_at.clone(),
+        };
+        let duplicate = activity.iter().any(|existing| {
+            existing.kind == entry.kind
+                && existing.author == entry.author
+                && existing.body == entry.body
+                && existing.timestamp == entry.timestamp
+        });
+        if !duplicate {
+            activity.push(entry);
+        }
+    }
+    activity.sort_by(|left, right| {
+        parse_timestamp(&left.timestamp)
+            .cmp(&parse_timestamp(&right.timestamp))
+            .then_with(|| left.timestamp.cmp(&right.timestamp))
+    });
+    activity
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|value| value.with_timezone(&chrono::Utc))
+}
+
+fn activity_is_new(entry: &TimelineEntry, cutoff: chrono::DateTime<chrono::Utc>) -> bool {
+    parse_timestamp(&entry.timestamp)
+        .map(|timestamp| timestamp > cutoff)
+        .unwrap_or(false)
+}
+
+/// Format an RFC 3339 timestamp as a local, human-readable date.
+fn format_timestamp(timestamp: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .map(|dt| {
+            dt.with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M")
+                .to_string()
+        })
+        .unwrap_or_else(|_| timestamp.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(author: &str, body: &str, timestamp: &str) -> TimelineEntry {
+        TimelineEntry {
+            author: author.to_string(),
+            kind: TimelineKind::Comment,
+            body: body.to_string(),
+            timestamp: timestamp.to_string(),
+        }
+    }
+
+    #[test]
+    fn triggering_comment_is_merged_in_timestamp_order() {
+        let timeline = vec![
+            entry("alice", "first", "2026-07-01T10:00:00Z"),
+            entry("carol", "third", "2026-07-01T12:00:00Z"),
+        ];
+        let latest = LatestComment {
+            author: "bob".to_string(),
+            body: "second".to_string(),
+            created_at: "2026-07-01T11:00:00Z".to_string(),
+        };
+
+        let activity = merge_pr_activity(&timeline, Some(&latest));
+
+        assert_eq!(activity.len(), 3);
+        assert_eq!(activity[1].author, "bob");
+    }
+
+    #[test]
+    fn triggering_comment_is_deduplicated() {
+        let timeline = vec![entry("alice", "same", "2026-07-01T10:00:00Z")];
+        let latest = LatestComment {
+            author: "alice".to_string(),
+            body: "same".to_string(),
+            created_at: "2026-07-01T10:00:00Z".to_string(),
+        };
+
+        assert_eq!(merge_pr_activity(&timeline, Some(&latest)).len(), 1);
+    }
+
+    #[test]
+    fn triggering_comment_respects_read_cutoff() {
+        let latest = LatestComment {
+            author: "alice".to_string(),
+            body: "already read".to_string(),
+            created_at: "2026-07-01T10:00:00Z".to_string(),
+        };
+        let cutoff = parse_timestamp("2026-07-01T11:00:00Z").unwrap();
+        let activity = merge_pr_activity(&[], Some(&latest));
+
+        assert!(!activity_is_new(&activity[0], cutoff));
     }
 }

--- a/src/ui/components/preview.rs
+++ b/src/ui/components/preview.rs
@@ -21,6 +21,9 @@ pub struct PreviewWidget {
     scrollbar_state: ScrollbarState,
     cached_lines: Vec<Line<'static>>,
     cached_signature: Option<String>,
+    /// Wrapped line count of `cached_lines` for a given width, so
+    /// `Paragraph::line_count` is not recomputed every frame.
+    cached_height: Option<(u16, usize)>,
     expanded_ci_key: Option<String>,
 }
 
@@ -32,6 +35,7 @@ impl PreviewWidget {
             scrollbar_state: ScrollbarState::default(),
             cached_lines: Vec::new(),
             cached_signature: None,
+            cached_height: None,
             expanded_ci_key: None,
         }
     }
@@ -54,6 +58,7 @@ impl PreviewWidget {
             self.expanded_ci_key = Some(key);
         }
         self.cached_signature = None;
+        self.cached_height = None;
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, state: &AppState) {
@@ -239,12 +244,13 @@ impl PreviewWidget {
                 .selected_notification()
                 .and_then(|n| state.effective_read_cutoff(n));
             let signature = format!(
-                "pr|{:?}|{:?}|{}|{}",
-                preview_data, cutoff, area.width, ci_expanded
+                "pr|{}|{:?}|{}|{}",
+                state.preview_content_version, cutoff, area.width, ci_expanded
             );
             if self.cached_signature.as_ref() != Some(&signature) {
                 self.cached_lines = self.build_pr_lines(preview_data, cutoff, ci_expanded);
                 self.cached_signature = Some(signature);
+                self.cached_height = None;
             }
         } else {
             let preview_view = PreviewView::from(preview_data);
@@ -270,6 +276,7 @@ impl PreviewWidget {
 
                 self.cached_signature = Some(signature);
                 self.cached_lines = all_lines;
+                self.cached_height = None;
             }
         }
 
@@ -288,7 +295,15 @@ impl PreviewWidget {
             .wrap(ratatui::widgets::Wrap { trim: false });
 
         // Wrapped visual rows, so long comment lines scroll correctly.
-        let content_height = paragraph.line_count(area.width);
+        // Recomputed only when the cached content or the pane width changes.
+        let content_height = match self.cached_height {
+            Some((width, height)) if width == area.width => height,
+            _ => {
+                let height = paragraph.line_count(area.width);
+                self.cached_height = Some((area.width, height));
+                height
+            }
+        };
         let max_scroll = content_height.saturating_sub(visible_height);
         let offset = state.preview_scroll.min(max_scroll);
 
@@ -356,6 +371,7 @@ impl PreviewWidget {
             additions,
             deletions,
             changed_files,
+            body,
             latest_comment,
             ci_checks,
             ci_total_count,
@@ -509,6 +525,14 @@ impl PreviewWidget {
             )]));
         }
         lines.push(Line::from(""));
+
+        // ── Description ──────────────────────────────────────────────────
+        if !body.trim().is_empty() {
+            lines.push(self.section_heading("Description", Vec::new()));
+            lines.push(Line::from(""));
+            lines.extend(MarkdownRenderer::render_simple(body, colors));
+            lines.push(Line::from(""));
+        }
 
         // ── New activity since last read ─────────────────────────────────
         let activity = merge_pr_activity(timeline, latest_comment.as_ref());


### PR DESCRIPTION
Added direct pull request merging from the preview pane with a
confirmation prompt, allowing users to complete merges without
switching to a browser. Configured default merge strategies via
the application settings.

Redesigned pull request previews to display status chips for
mergeability, review approvals, and build status. Included a timeline
feed of comments and review activity published since last reading the
notification, alongside collapsible individual build check results.
Tracked local read timestamps so new thread activity stays accurate
when marking notifications read.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
